### PR TITLE
書き込み前のコールバックの修正

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/io/CsvAnnotationBeanWriter.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/CsvAnnotationBeanWriter.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -186,11 +187,8 @@ public class CsvAnnotationBeanWriter<T> extends AbstractCsvWriter {
         // update the current row/line numbers
         super.incrementRowAndLineNo();
         
-        // extract the bean values
-        extractBeanValues(source, beanMapping.getNameMapping());
-        
         final CsvContext context = new CsvContext(getLineNumber(), getRowNumber(), 1);
-        context.setRowSource(new ArrayList<Object>(beanValues));
+        context.setRowSource(Collections.emptyList());  // 空の値を入れる
         
         final CsvBindingErrors bindingErrors = new CsvBindingErrors(beanMapping.getOriginal().getType());
         
@@ -198,6 +196,10 @@ public class CsvAnnotationBeanWriter<T> extends AbstractCsvWriter {
         for(CallbackMethod callback : beanMapping.getOriginal().getPreWriteMethods()) {
             callback.invoke(source, context, bindingErrors, beanMapping.getOriginal());
         }
+        
+        // extract the bean values
+        extractBeanValues(source, beanMapping.getNameMapping());
+        context.setRowSource(new ArrayList<Object>(beanValues));
         
         Optional<SuperCsvRowException> rowException = Optional.empty();
         try {


### PR DESCRIPTION
## 事象
書き込み時のコールバック ``@CsvPreWrite`` を利用して、Beanのフィールドの値を編集しても、出力したファイルに反映されない。

## 原因
コールバック関数を呼ぶ前に、Beanのフィールドの値を抽出して、それをそのまま書き込んでいたため。

## 対策
そのため、コールバック関数を呼んだ後に、Beanのフィールドの値を抽出するよう修正。
ただし、書き込み前の ``CsvContext#rowSource`` の値は空になります。
