### PR TITLE
RegexReplaceの部分一致の対応

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/cellprocessor/conversion/RegexReplace.java
+++ b/src/main/java/com/github/mygreen/supercsv/cellprocessor/conversion/RegexReplace.java
@@ -75,7 +75,7 @@ public class RegexReplace extends CellProcessorAdaptor implements StringCellProc
         }
         
         final Matcher matcher = pattern.matcher(value.toString());
-        if(matcher.matches()) {
+        if(matcher.find()) {
             final String result = matcher.replaceAll(replacement);
             return next.execute(result, context);
         }

--- a/src/test/java/com/github/mygreen/supercsv/cellprocessor/conversion/RegexReplaceTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/cellprocessor/conversion/RegexReplaceTest.java
@@ -89,4 +89,22 @@ public class RegexReplaceTest {
         
         assertThat((Object)processor.execute(null, ANONYMOUS_CSVCONTEXT)).isNull();
     }
+
+    /**
+     * Tests unchained/chained execution with partial matching.
+     */
+    @Test
+    public void testExecute_partial_match() {
+        Pattern partialPattern = Pattern.compile("Word");
+        String replacement = "Replace";
+
+        this.processor = new RegexReplace(partialPattern, replacement);
+        this.processorChain = new RegexReplace(partialPattern, replacement, new NextCellProcessor());
+
+        String input = "xxxWordyyyWordzzz";
+        String output = "xxxReplaceyyyReplacezzz";
+
+        assertThat((Object)processor.execute(input, ANONYMOUS_CSVCONTEXT)).isEqualTo(output);
+        assertThat((Object)processorChain.execute(input, ANONYMOUS_CSVCONTEXT)).isEqualTo(output);
+    }
 }


### PR DESCRIPTION
#34 の対応

- `matcher.matches`ではなく`matcher.find`を使用するように修正
