### PR TITLE
ResourceBundleで読み込むメッセージファイルをasciiコードに変換した物からUTF-8に変更。

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/localization/EncodingControl.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/EncodingControl.java
@@ -1,0 +1,145 @@
+package com.github.mygreen.supercsv.localization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+/**
+ * {@link ResourceBundle}を任意の文字コードで読み込むためのコントローラ。
+ *
+ * @since 2.2
+ * @author T.TSUCHIE
+ *
+ */
+public class EncodingControl extends ResourceBundle.Control {
+    
+    private final Charset encoding;
+    
+    /**
+     * 文字コードUTF-8で設定する
+     */
+    public EncodingControl() {
+        this("UTF-8");
+    }
+    
+    public EncodingControl(final String encoding) {
+        this(Charset.forName(encoding));
+    }
+    
+    public EncodingControl(final Charset encoding) {
+        this.encoding = encoding;
+    }
+    
+    @Override
+    public ResourceBundle newBundle(final String baseName, final Locale locale, String format, final ClassLoader loader, final boolean reload) 
+            throws IllegalAccessException, InstantiationException, IOException {
+        
+        String bundleName = toBundleName(baseName, locale);
+        ResourceBundle bundle = null;
+        if (format.equals("java.class"))
+        {
+          try
+          {
+            @SuppressWarnings(
+            { "unchecked" })
+            Class<? extends ResourceBundle> bundleClass = (Class<? extends ResourceBundle>) loader.loadClass(bundleName);
+
+            // If the class isn't a ResourceBundle subclass, throw a
+            // ClassCastException.
+            if (ResourceBundle.class.isAssignableFrom(bundleClass))
+            {
+              bundle = bundleClass.newInstance();
+            }
+            else
+            {
+              throw new ClassCastException(bundleClass.getName() + " cannot be cast to ResourceBundle");
+            }
+          }
+          catch (ClassNotFoundException ignored)
+          {
+          }
+        }
+        else if (format.equals("java.properties"))
+        {
+          final String resourceName = toResourceName(bundleName, "properties");
+          final ClassLoader classLoader = loader;
+          final boolean reloadFlag = reload;
+          InputStreamReader isr = null;
+          InputStream stream;
+          try
+          {
+            stream = AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>()
+            {
+              @Override
+              public InputStream run() throws IOException
+              {
+                InputStream is = null;
+                if (reloadFlag)
+                {
+                  URL url = classLoader.getResource(resourceName);
+                  if (url != null)
+                  {
+                    URLConnection connection = url.openConnection();
+                    if (connection != null)
+                    {
+                      // Disable caches to get fresh data for
+                      // reloading.
+                      connection.setUseCaches(false);
+                      is = connection.getInputStream();
+                    }
+                  }
+                }
+                else
+                {
+                  is = classLoader.getResourceAsStream(resourceName);
+                }
+                return is;
+              }
+            });
+            if (stream != null)
+            {
+              isr = new InputStreamReader(stream, encoding);
+            }
+          }
+          catch (PrivilegedActionException e)
+          {
+            throw (IOException) e.getException();
+          }
+          if (isr != null)
+          {
+            try
+            {
+              bundle = new PropertyResourceBundle(isr);
+            }
+            finally
+            {
+              isr.close();
+            }
+          }
+        }
+        else
+        {
+          throw new IllegalArgumentException("unknown format: " + format);
+        }
+        return bundle;
+    }
+    
+    
+    /**
+     * 設定されている文字コードを取得します。
+     * @return リソースファイルの文字コード。
+     */
+    public Charset getEncoding() {
+        return encoding;
+    }
+
+}

--- a/src/main/java/com/github/mygreen/supercsv/localization/Messages.properties
+++ b/src/main/java/com/github/mygreen/supercsv/localization/Messages.properties
@@ -1,31 +1,31 @@
 ####################################
-# \u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8
+# エラーメッセージ
 ####################################
 
-noinit.onLazyRead=\u898b\u51fa\u3057\u60c5\u5831\u3092\u5143\u306b\u3057\u305f\u521d\u671f\u5316\u304c\u5b8c\u4e86\u3057\u3066\u3044\u307e\u305b\u3093\u3002LazyCsvAnnotationBeanReader#init() \u3067\u521d\u671f\u5316\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002
-noinit.onLazyWrite=\u898b\u51fa\u3057\u60c5\u5831\u3092\u5143\u306b\u3057\u305f\u521d\u671f\u5316\u304c\u5b8c\u4e86\u3057\u3066\u3044\u307e\u305b\u3093\u3002LazyCsvAnnotationBeanWriter#init() \u3067\u521d\u671f\u5316\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002
+noinit.onLazyRead=見出し情報を元にした初期化が完了していません。LazyCsvAnnotationBeanReader#init() で初期化する必要があります。
+noinit.onLazyWrite=見出し情報を元にした初期化が完了していません。LazyCsvAnnotationBeanWriter#init() で初期化する必要があります。
 
-anno.notFound='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3002
-anno.required='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u4ed8\u4e0e\u306f\u5fc5\u9808\u3067\u3059\u3002
+anno.notFound='{property}' において、アノテーション {anno} が見つかりません。
+anno.required='{property}' において、アノテーション {anno} の付与は必須です。
 
-anno.attr.required='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 '{attrName}' \u306e\u6307\u5b9a\u306f\u5fc5\u9808\u3067\u3059\u3002
-anno.attr.duplicated='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 '{attrName}' \u306e\u5024\uff08[${f:join(attrValues, ', ')}]\uff09\u304c\u91cd\u8907\u3057\u3066\u3044\u307e\u3059\u3002
-anno.attr.min='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 '{attrName}' \u306e\u5024\uff08{attrValue}\uff09\u306f\u3001{min}\u4ee5\u4e0a\u306e\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-anno.attr.invalidType='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 '{attrName}' \u306e\u5024\uff08{attrValue}\uff09\u306f\u3001{type}${empty(pattern) ? '' : ' (' + pattern + ')'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+anno.attr.required='{property}' において、アノテーション {anno} の属性 '{attrName}' の指定は必須です。
+anno.attr.duplicated='{property}' において、アノテーション {anno} の属性 '{attrName}' の値（[${f:join(attrValues, ', ')}]）が重複しています。
+anno.attr.min='{property}' において、アノテーション {anno} の属性 '{attrName}' の値（{attrValue}）は、{min}以上の値を設定してください。
+anno.attr.invalidType='{property}' において、アノテーション {anno} の属性 '{attrName}' の値（{attrValue}）は、{type}${empty(pattern) ? '' : ' (' + pattern + ')'}として不正です。
 
-anno.CsvWordReplace.invalidSize='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 'words' \u3068 'replacements' \u306e\u914d\u5217\u306e\u30b5\u30a4\u30ba\u304c\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002\u8a2d\u5b9a\u3055\u308c\u3066\u3044\u308b\u5c5e\u6027 'words' \u306e\u30b5\u30a4\u30ba\u306f{wordsSize}\u3001'replacements' \u306e\u30b5\u30a4\u30ba\u306f{replacementsSize}\u3067\u3059\u3002
-anno.CsvDateTimeRange.minMaxWrong='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 'min' \u306e\u5024\uff08{minValue}\uff09\u306f\u3001\u5c5e\u6027 'max' \u306e\u5024\uff08{maxValue}\uff09\u3088\u308a\u4ee5\u524d\u306e\u5024\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-anno.CsvNumberRange.minMaxWrong='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 'min' \u306e\u5024\uff08{minValue}\uff09\u306f\u3001\u5c5e\u6027 'max' \u306e\u5024\uff08{maxValue}\uff09\u4ee5\u4e0b\u306e\u5024\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-anno.CsvLengthBetween.minMaxWrong='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {anno} \u306e\u5c5e\u6027 'min' \u306e\u5024\uff08{minValue}\uff09\u306f\u3001\u5c5e\u6027 'max' \u306e\u5024\uff08{maxValue}\uff09\u4ee5\u4e0b\u306e\u5024\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+anno.CsvWordReplace.invalidSize='{property}' において、アノテーション {anno} の属性 'words' と 'replacements' の配列のサイズが一致しません。設定されている属性 'words' のサイズは{wordsSize}、'replacements' のサイズは{replacementsSize}です。
+anno.CsvDateTimeRange.minMaxWrong='{property}' において、アノテーション {anno} の属性 'min' の値（{minValue}）は、属性 'max' の値（{maxValue}）より以前の値で設定してください。
+anno.CsvNumberRange.minMaxWrong='{property}' において、アノテーション {anno} の属性 'min' の値（{minValue}）は、属性 'max' の値（{maxValue}）以下の値で設定してください。
+anno.CsvLengthBetween.minMaxWrong='{property}' において、アノテーション {anno} の属性 'min' の値（{minValue}）は、属性 'max' の値（{maxValue}）以下の値で設定してください。
 
-anno.CsvPartial.columSizeMin='{property}' \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 @CsvPartial \u306e\u5c5e\u6027 'columnSize' \u306e\u5024 ({columnSize}) \u306f\u3001\u5b9a\u7fa9\u3057\u3066\u3044\u308b\u6700\u5927\u306e @CsvColumn \u306e\u5c5e\u6027 'number' \u306e\u5024\uff08{maxColumnNumber}\uff09\u4ee5\u4e0a\u306e\u8a2d\u5b9a\u3092\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+anno.CsvPartial.columSizeMin='{property}' において、アノテーション @CsvPartial の属性 'columnSize' の値 ({columnSize}) は、定義している最大の @CsvColumn の属性 'number' の値（{maxColumnNumber}）以上の設定をしてください。
 
-anno.CsvOverridesAnnotation.notFoundAttr=\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {compositionAnno} \u306b\u304a\u3044\u3066\u3001\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 @CsvOverridesAnnotation \u3067\u4e0a\u66f8\u304d\u3059\u308b\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {overrideAnno} \u306e\u5c5e\u6027({attrType} {attrName}) \u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3002
-anno.CsvOverridesAnnotation.failGetAttr=\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3 {compositionAnno} \u306e\u5c5e\u6027 '{attrName}' \u306e\u5024\u306e\u53d6\u5f97\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
+anno.CsvOverridesAnnotation.notFoundAttr=アノテーション {compositionAnno} において、アノテーション @CsvOverridesAnnotation で上書きするアノテーション {overrideAnno} の属性({attrType} {attrName}) が見つかりません。
+anno.CsvOverridesAnnotation.failGetAttr=アノテーション {compositionAnno} の属性 '{attrName}' の値の取得に失敗しました。
 
-lazy.noDeteminedColumns='{property}' \u306e\u30d8\u30c3\u30c0\u30fc\uff08[${f:join(headers, ', ')}]\uff09\u306b\u304a\u3044\u3066\u3001\u5b9a\u7fa9\u3057\u3066\u3044\u308b\u304c\u4e00\u81f4\u3057\u306a\u3044\u30e9\u30d9\u30eb\uff08[${f:join(labels, ', ')}]\uff09\u304c\u3042\u308a\u307e\u3059\u3002
+lazy.noDeteminedColumns='{property}' のヘッダー（[${f:join(headers, ', ')}]）において、定義しているが一致しないラベル（[${f:join(labels, ', ')}]）があります。
 
-# \u5358\u8a9e\u306e\u5b9a\u7fa9
-key.regex=\u6b63\u898f\u8868\u73fe
-key.dateTime=\u65e5\u6642
+# 単語の定義
+key.regex=正規表現
+key.dateTime=日時
 

--- a/src/main/java/com/github/mygreen/supercsv/localization/ResourceBundleMessageResolver.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/ResourceBundleMessageResolver.java
@@ -18,7 +18,7 @@ import com.github.mygreen.supercsv.util.ArgUtils;
  * <p>クラスパスのルートにリソース名が{@literal SuperCsvMessages}のプロパティファイルを配置していると自動的に読み込みます。</p>
  * <p>デフォルトでは、{@link ResourceBundleMessageResolver#DEFAULT_MESSAGE}に配置されているリソースファイルを読み込みます。</p>
  * 
- * @version 2.0
+ * @version 2.2
  * @author T.TSUCHIE
  *
  */
@@ -44,7 +44,7 @@ public class ResourceBundleMessageResolver implements MessageResolver {
     public ResourceBundleMessageResolver(final String baseName, final boolean appendUserResource) {
         ArgUtils.notEmpty(baseName, "baseName");
         
-        addResourceBundle(ResourceBundle.getBundle(baseName));
+        addResourceBundle(ResourceBundle.getBundle(baseName, new EncodingControl("UTF-8")));
         
         // ユーザ定義のリソースを読み込む
         if(appendUserResource) {
@@ -53,7 +53,7 @@ public class ResourceBundleMessageResolver implements MessageResolver {
             if(index > 0) {
                 final String userName = baseName.substring(index+1);
                 try {
-                    addResourceBundle(ResourceBundle.getBundle(userName));
+                    addResourceBundle(ResourceBundle.getBundle(userName, new EncodingControl("UTF-8")));
                 } catch(Throwable e) { }
             }
         }

--- a/src/main/java/com/github/mygreen/supercsv/localization/SuperCsvMessages.properties
+++ b/src/main/java/com/github/mygreen/supercsv/localization/SuperCsvMessages.properties
@@ -1,50 +1,50 @@
 #######################################################
 # Suepr CSV Annotation default validation messages.
 #######################################################
-# \u5171\u901a\u5909\u6570
-# {lineNumber} - \u73fe\u5728\u3001\u66f8\u304d\u8fbc\u3093\u3060\uff0f\u8aad\u307f\u8fbc\u3093\u3060\u884c\u6570
-# {rowNumber} - CSV\u306e\u884c\u756a\u53f7
-# {columnNumber} - CSV\u306e\u5217\u756a\u53f7
-# {label} - CSV\u306e\u5217\u30e9\u30d9\u30eb
-# {validatedValue} = \u30a8\u30e9\u30fc\u306e\u539f\u56e0\u3068\u306a\u3063\u305f\u5024
+# 共通変数
+# {lineNumber} - 現在、書き込んだ／読み込んだ行数
+# {rowNumber} - CSVの行番号
+# {columnNumber} - CSVの列番号
+# {label} - CSVの列ラベル
+# {validatedValue} = エラーの原因となった値
 #######################################################
 
-csvContext=[{rowNumber}\u884c, {columnNumber}\u5217]
+csvContext=[{rowNumber}行, {columnNumber}列]
 
-csvError={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306f\u4e0d\u6b63\u306a\u5024\u3067\u3059
-csvError.noMatchColumnSize=[{rowNumber}\u884c] : \u5217\u6570\u304c\u4e0d\u6b63\u3067\u3059\u3002 {expectedSize}\u5217\u3067\u8a2d\u5b9a\u3059\u3079\u304d\u3067\u3059\u304c\u3001\u5b9f\u969b\u306b\u306f{actualSize}\u5217\u306b\u306a\u3063\u3066\u3044\u307e\u3059\u3002
-csvError.noMatchHeader=[{rowNumber}\u884c]  : \u30d8\u30c3\u30c0\u30fc\u306e\u5024\u300c{joinedActualHeaders}\u300d\u306f\u3001\u300c{joinedExpectedHeaders}\u300d\u3068\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002
+csvError={csvContext} : 項目「{label}」は不正な値です
+csvError.noMatchColumnSize=[{rowNumber}行] : 列数が不正です。 {expectedSize}列で設定すべきですが、実際には{actualSize}列になっています。
+csvError.noMatchHeader=[{rowNumber}行]  : ヘッダーの値「{joinedActualHeaders}」は、「{joinedExpectedHeaders}」と一致しません。
 
 
 
-# CellProcessor\u306e\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8
-com.github.mygreen.supercsv.cellprocessor.constraint.Require.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u5fc5\u9808\u3067\u3059\u3002
+# CellProcessorのエラーメッセージ
+com.github.mygreen.supercsv.cellprocessor.constraint.Require.violated={csvContext} : 項目「{label}」の値は必須です。
 
-com.github.mygreen.supercsv.cellprocessor.constraint.LengthMin.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u6587\u5b57\u5217\u9577\uff08{length}\uff09\u306f\u3001{min}\u6587\u5b57\u4ee5\u4e0a\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.LengthMax.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u6587\u5b57\u5217\u9577\uff08{length}\uff09\u306f\u3001{max}\u6587\u5b57\u4ee5\u5185\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.LengthBetween.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u6587\u5b57\u5217\u9577\uff08{length}\uff09\u306f\u3001{min}\uff5e{max}\u6587\u5b57\u306e\u7bc4\u56f2\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.LengthExact.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u6587\u5b57\u5217\u9577\uff08{length}\uff09\u306f\u3001${f:join(requiredLengths, ', ')}\u6587\u5b57${size(requiredLengths) == 1 ? '' : '\u306e\u4f55\u308c\u304b'}\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+com.github.mygreen.supercsv.cellprocessor.constraint.LengthMin.violated={csvContext} : 項目「{label}」の文字列長（{length}）は、{min}文字以上でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.LengthMax.violated={csvContext} : 項目「{label}」の文字列長（{length}）は、{max}文字以内でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.LengthBetween.violated={csvContext} : 項目「{label}」の文字列長（{length}）は、{min}～{max}文字の範囲でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.LengthExact.violated={csvContext} : 項目「{label}」の文字列長（{length}）は、${f:join(requiredLengths, ', ')}文字${size(requiredLengths) == 1 ? '' : 'の何れか'}でなければなりません。
 
-com.github.mygreen.supercsv.cellprocessor.constraint.NumberMin.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${empty(printer) ? min : printer.print(min)}${inclusive ? '\u4ee5\u4e0a\u306e\u5024' : '\u3088\u308a\u5927\u304d\u3044\u5024'}\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.NumberMax.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${empty(printer) ? max : printer.print(max)}${inclusive ? '\u4ee5\u4e0b\u306e\u5024' : '\u3088\u308a\u5c0f\u3055\u3044\u5024'}\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.NumberRange.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${empty(printer) ? min : printer.print(min)}\uff5e${empty(printer) ? max : printer.print(max)}\u306e\u7bc4\u56f2\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+com.github.mygreen.supercsv.cellprocessor.constraint.NumberMin.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${empty(printer) ? min : printer.print(min)}${inclusive ? '以上の値' : 'より大きい値'}でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.NumberMax.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${empty(printer) ? max : printer.print(max)}${inclusive ? '以下の値' : 'より小さい値'}でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.NumberRange.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${empty(printer) ? min : printer.print(min)}～${empty(printer) ? max : printer.print(max)}の範囲でなければなりません。
 
-com.github.mygreen.supercsv.cellprocessor.constraint.DateTimeMin.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${empty(printer) ? min : printer.print(min)}${inclusive ? '\u4ee5\u964d\u306e\u5024' : '\u3088\u308a\u5f8c\u306e\u5024'}\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.DateTimeMax.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${empty(printer) ? max : printer.print(max)}${inclusive ? '\u4ee5\u524d\u306e\u5024' : '\u3088\u308a\u524d\u306e\u5024'}\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.DateTimeRange.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${empty(printer) ? min : printer.print(min)}\uff5e${empty(printer) ? max : printer.print(max)} \u306e\u671f\u9593\u5185\u3067\u306a\u3051\u308c\u3070\u306a\u308a\u307e\u305b\u3093\u3002
+com.github.mygreen.supercsv.cellprocessor.constraint.DateTimeMin.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${empty(printer) ? min : printer.print(min)}${inclusive ? '以降の値' : 'より後の値'}でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.DateTimeMax.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${empty(printer) ? max : printer.print(max)}${inclusive ? '以前の値' : 'より前の値'}でなければなりません。
+com.github.mygreen.supercsv.cellprocessor.constraint.DateTimeRange.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${empty(printer) ? min : printer.print(min)}～${empty(printer) ? max : printer.print(max)} の期間内でなければなりません。
 
-com.github.mygreen.supercsv.cellprocessor.constraint.Equals.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${size(equalsValues) == 1 ? '' : '\u4f55\u308c\u304b\u306e' }\u5024\u300c${f:join(equalsValues, ', ', printer)}\u300d\u3068\u4e00\u81f4\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.Unique.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{duplicatedRowNumber}\u884c\u76ee\u306e\u5024\u3068\u91cd\u8907\u3057\u3066\u3044\u307e\u3059\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.UniqueHashCode.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{duplicatedRowNumber}\u884c\u76ee\u306e\u5024\u3068\u91cd\u8907\u3057\u3066\u3044\u307e\u3059\u3002
+com.github.mygreen.supercsv.cellprocessor.constraint.Equals.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${size(equalsValues) == 1 ? '' : '何れかの' }値「${f:join(equalsValues, ', ', printer)}」と一致する必要があります。
+com.github.mygreen.supercsv.cellprocessor.constraint.Unique.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{duplicatedRowNumber}行目の値と重複しています。
+com.github.mygreen.supercsv.cellprocessor.constraint.UniqueHashCode.violated={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{duplicatedRowNumber}行目の値と重複しています。
 
-com.github.mygreen.supercsv.cellprocessor.constraint.WordForbid.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306b\u306f\u3001\u7981\u6b62\u8a9e\u5f59 \u300c${f:join(words, ', ')}\u300d\u304c\u542b\u307e\u308c\u3066\u3044\u307e\u3059\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.WordRequire.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306b\u306f\u3001\u5fc5\u9808\u8a9e\u5f59 \u300c${f:join(words, ', ')}\u300d${size(words) == 1 ? '' : '\u306e\u4f55\u308c\u304b' }\u304c\u542b\u307e\u308c\u3066\u3044\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.cellprocessor.constraint.Pattern.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001${empty(description) ? '\u6b63\u898f\u8868\u73fe\u300c' + regex + '\u300d' : description}\u306b\u4e00\u81f4\u3057\u307e\u305b\u3093\u3002
+com.github.mygreen.supercsv.cellprocessor.constraint.WordForbid.violated={csvContext} : 項目「{label}」の値（{validatedValue}）には、禁止語彙 「${f:join(words, ', ')}」が含まれています。
+com.github.mygreen.supercsv.cellprocessor.constraint.WordRequire.violated={csvContext} : 項目「{label}」の値（{validatedValue}）には、必須語彙 「${f:join(words, ', ')}」${size(words) == 1 ? '' : 'の何れか' }が含まれていません。
+com.github.mygreen.supercsv.cellprocessor.constraint.Pattern.violated={csvContext} : 項目「{label}」の値（{validatedValue}）は、${empty(description) ? '正規表現「' + regex + '」' : description}に一致しません。
 
-com.github.mygreen.supercsv.cellprocessor.format.ParseProcessor.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306e\u66f8\u5f0f\u306f\u4e0d\u6b63\u3067\u3059\u3002
-com.github.mygreen.supercsv.cellprocessor.format.PrintProcessor.violated={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306e\u66f8\u304d\u8fbc\u307f\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
+com.github.mygreen.supercsv.cellprocessor.format.ParseProcessor.violated={csvContext} : 項目「{label}」の値（{validatedValue}）の書式は不正です。
+com.github.mygreen.supercsv.cellprocessor.format.PrintProcessor.violated={csvContext} : 項目「{label}」の値の書き込みに失敗しました。
 
-# \u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u306e\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8\uff08CellProcessor\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306b\u7f6e\u63db\u3059\u308b\uff09
+# アノテーションのエラーメッセージ（CellProcessorのメッセージに置換する）
 com.github.mygreen.supercsv.annotation.constraint.CsvRequire.message={com.github.mygreen.supercsv.cellprocessor.constraint.Require.violated}
 
 com.github.mygreen.supercsv.annotation.constraint.CsvLengthMin.message={com.github.mygreen.supercsv.cellprocessor.constraint.LengthMin.violated}
@@ -68,68 +68,68 @@ com.github.mygreen.supercsv.annotation.constraint.CsvWordForbid.message={com.git
 com.github.mygreen.supercsv.annotation.constraint.CsvWordRequire.message={com.github.mygreen.supercsv.cellprocessor.constraint.WordRequire.violated}
 com.github.mygreen.supercsv.annotation.constraint.CsvPattern.message={com.github.mygreen.supercsv.cellprocessor.constraint.Pattern.violated}
 
-com.github.mygreen.supercsv.annotation.format.CsvBooleanFormat.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001true\u306e\u5024\u300c${f:join(trueValues, ', ')}\u300d\u3001\u307e\u305f\u306ffalse\u306e\u5024\u300c${f:join(falseValues, ', ')}\u300d\u306e\u4f55\u308c\u304b\u306e\u5024\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-com.github.mygreen.supercsv.annotation.format.CsvEnumFormat.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u4f55\u308c\u304b\u306e\u5024\u300c${f:join(enums, ', ')}\u300d\u3067\u3042\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002
-com.github.mygreen.supercsv.annotation.format.CsvNumberFormat.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6570\u5024\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-com.github.mygreen.supercsv.annotation.format.CsvDateTimeFormat.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+com.github.mygreen.supercsv.annotation.format.CsvBooleanFormat.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、trueの値「${f:join(trueValues, ', ')}」、またはfalseの値「${f:join(falseValues, ', ')}」の何れかの値で設定してください。
+com.github.mygreen.supercsv.annotation.format.CsvEnumFormat.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、何れかの値「${f:join(enums, ', ')}」である必要があります。
+com.github.mygreen.supercsv.annotation.format.CsvNumberFormat.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、数値の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+com.github.mygreen.supercsv.annotation.format.CsvDateTimeFormat.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
 
-## JSR-303/310((BeanValidation 1.0/1.1)\u306e\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8
-javax.validation.constraints.AssertFalse.message=false\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.AssertTrue.message=true\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.DecimalMax.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{value}${inclusive == true ? '\u4ee5\u4e0b\u306e' : '\u3088\u308a\u5c0f\u3055\u3044'}\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.DecimalMin.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{value}${inclusive == true ? '\u4ee5\u4e0a\u306e' : '\u3088\u308a\u5927\u304d\u3044'}\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Digits.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u6574\u6570{integer}\u6841\u4ee5\u5185\u3001\u5c0f\u6570{fraction}\u6841\u4ee5\u5185\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Future.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u672a\u6765\u306e\u65e5\u4ed8\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Max.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{value}\u3088\u308a\u540c\u3058\u304b\u5c0f\u3055\u3044\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002 
-javax.validation.constraints.Min.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{value}\u3088\u308a\u540c\u3058\u304b\u5927\u304d\u3044\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.NotNull.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u5fc5\u9808\u3067\u3059\u3002
-javax.validation.constraints.Null.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u672a\u8a2d\u5b9a\u3067\u306a\u3051\u308c\u3070\u3044\u3051\u307e\u305b\u3093\u3002
-javax.validation.constraints.Past.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u904e\u53bb\u306e\u65e5\u4ed8\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Pattern.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u6b63\u898f\u8868\u73fe\u300c{regexp}\u300d\u306b\u4e00\u81f4\u3057\u3066\u3044\u307e\u305b\u3093\u3002
-javax.validation.constraints.Size.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306e\u30b5\u30a4\u30ba\u306f\u3001{min}\u304b\u3089{max}\u306e\u9593\u306e\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+## JSR-303/310((BeanValidation 1.0/1.1)のエラーメッセージ
+javax.validation.constraints.AssertFalse.message=falseを設定してください。
+javax.validation.constraints.AssertTrue.message=trueを設定してください。
+javax.validation.constraints.DecimalMax.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{value}${inclusive == true ? '以下の' : 'より小さい'}値を設定してください。
+javax.validation.constraints.DecimalMin.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{value}${inclusive == true ? '以上の' : 'より大きい'}値を設定してください。
+javax.validation.constraints.Digits.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、整数{integer}桁以内、小数{fraction}桁以内で設定してください。
+javax.validation.constraints.Future.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、未来の日付を設定してください。
+javax.validation.constraints.Max.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{value}より同じか小さい値を設定してください。 
+javax.validation.constraints.Min.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{value}より同じか大きい値を設定してください。
+javax.validation.constraints.NotNull.message={csvContext} : 項目「{label}」の値は必須です。
+javax.validation.constraints.Null.message={csvContext} : 項目「{label}」の値は未設定でなければいけません。
+javax.validation.constraints.Past.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、過去の日付を設定してください。
+javax.validation.constraints.Pattern.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、正規表現「{regexp}」に一致していません。
+javax.validation.constraints.Size.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）のサイズは、{min}から{max}の間の値を設定してください。
 
-## JSR-380(BeanValidation 2.0)\u306e\u30e1\u30c3\u30bb\u30fc\u30b8
-javax.validation.constraints.NotEmpty.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u5fc5\u9808\u3067\u3059\u3002
-javax.validation.constraints.NotBlank.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u5fc5\u9808\u3067\u3059\u3002
-javax.validation.constraints.FutureOrPresent.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u73fe\u5728\u4ee5\u964d\u306e\u672a\u6765\u306e\u65e5\u4ed8\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.PastOrPresent.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u73fe\u5728\u4ee5\u524d\u306e\u904e\u53bb\u306e\u65e5\u4ed8\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Negative.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u30010\u3088\u308a\u5c0f\u3055\u3044\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.NegativeOrZero.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u30010\u4ee5\u4e0b\u306e\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Positive.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u30010\u3088\u308a\u5927\u304d\u3044\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.PositiveOrZero.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u30010\u4ee5\u4e0a\u306e\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-javax.validation.constraints.Email.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001E-mail\u5f62\u5f0f\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+## JSR-380(BeanValidation 2.0)のメッセージ
+javax.validation.constraints.NotEmpty.message={csvContext} : 項目「{label}」の値は必須です。
+javax.validation.constraints.NotBlank.message={csvContext} : 項目「{label}」の値は必須です。
+javax.validation.constraints.FutureOrPresent.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、現在以降の未来の日付を設定してください。
+javax.validation.constraints.PastOrPresent.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、現在以前の過去の日付を設定してください。
+javax.validation.constraints.Negative.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、0より小さい値を設定してください。
+javax.validation.constraints.NegativeOrZero.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、0以下の値を設定してください。
+javax.validation.constraints.Positive.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、0より大きい値を設定してください。
+javax.validation.constraints.PositiveOrZero.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、0以上の値を設定してください。
+javax.validation.constraints.Email.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、E-mail形式で設定してください。
 
 
-## Hibernate Validator\u306e\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8
-org.hibernate.validator.constraints.CreditCardNumber.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u4e0d\u6b63\u306a\u30af\u30ec\u30b8\u30c3\u30c8\u30ab\u30fc\u30c9\u306e\u756a\u53f7\u3067\u3059\u3002
-org.hibernate.validator.constraints.EAN.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u4e0d\u6b63\u306a{type}\u306e\u30b3\u30fc\u30c9\u3067\u3059\u3002
-org.hibernate.validator.constraints.Email.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001E-mail\u5f62\u5f0f\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-org.hibernate.validator.constraints.Length.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u6587\u5b57\u306e\u9577\u3055\u306f{min}\u304b\u3089{max}\u306e\u9593\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-org.hibernate.validator.constraints.LuhnCheck.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001Luhn Module 10 \u30c1\u30a7\u30c3\u30af\u30b5\u30e0\u306e\u5024\u304c\u4e0d\u6b63\u3067\u3059\u3002
-org.hibernate.validator.constraints.Mod10Check.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001Module 10 \u30c1\u30a7\u30c3\u30af\u30b5\u30e0\u306e\u5024\u304c\u4e0d\u6b63\u3067\u3059\u3002
-org.hibernate.validator.constraints.Mod11Check.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001Luhn Module 11 \u30c1\u30a7\u30c3\u30af\u30b5\u30e0\u306e\u5024\u304c\u4e0d\u6b63\u3067\u3059\u3002
-org.hibernate.validator.constraints.ModCheck.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${modType} \u30c1\u30a7\u30c3\u30af\u30b5\u30e0\u306e\u5024\u304c\u4e0d\u6b63\u3067\u3059\u3002
-org.hibernate.validator.constraints.NotBlank.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u5fc5\u9808\u3067\u3059\u3002
-org.hibernate.validator.constraints.NotEmpty.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u5fc5\u9808\u3067\u3059\u3002
-org.hibernate.validator.constraints.ParametersScriptAssert.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u30b9\u30af\u30ea\u30d7\u30c8\u306e\u5f0f"{script}"\u304ctrue\u3092\u8fd4\u3057\u307e\u305b\u3093\u3067\u3057\u305f\u3002
-org.hibernate.validator.constraints.Range.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001{min}\u304b\u3089{max}\u306e\u9593\u306e\u5024\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-org.hibernate.validator.constraints.SafeHtml.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u30b9\u30af\u30ea\u30d7\u30c8\u3092\u542b\u3093\u3067\u3044\u308b\u5b89\u5168\u3067\u306a\u3044\u53ef\u80fd\u6027\u304c\u3042\u308a\u307e\u3059\u3002
-org.hibernate.validator.constraints.ScriptAssert.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u30b9\u30af\u30ea\u30d7\u30c8\u306e\u5f0f"{script}"\u304ctrue\u3092\u8fd4\u3057\u307e\u305b\u3093\u3067\u3057\u305f\u3002
-org.hibernate.validator.constraints.URL.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u4e0d\u6b63\u306aURL\u306e\u5f62\u5f0f\u3067\u3059\u3002
+## Hibernate Validatorのエラーメッセージ
+org.hibernate.validator.constraints.CreditCardNumber.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、不正なクレジットカードの番号です。
+org.hibernate.validator.constraints.EAN.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、不正な{type}のコードです。
+org.hibernate.validator.constraints.Email.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、E-mail形式で設定してください。
+org.hibernate.validator.constraints.Length.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、文字の長さは{min}から{max}の間で設定してください。
+org.hibernate.validator.constraints.LuhnCheck.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、Luhn Module 10 チェックサムの値が不正です。
+org.hibernate.validator.constraints.Mod10Check.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、Module 10 チェックサムの値が不正です。
+org.hibernate.validator.constraints.Mod11Check.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、Luhn Module 11 チェックサムの値が不正です。
+org.hibernate.validator.constraints.ModCheck.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${modType} チェックサムの値が不正です。
+org.hibernate.validator.constraints.NotBlank.message={csvContext} : 項目「{label}」の値は必須です。
+org.hibernate.validator.constraints.NotEmpty.message={csvContext} : 項目「{label}」の値は必須です。
+org.hibernate.validator.constraints.ParametersScriptAssert.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、スクリプトの式"{script}"がtrueを返しませんでした。
+org.hibernate.validator.constraints.Range.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、{min}から{max}の間の値を設定してください。
+org.hibernate.validator.constraints.SafeHtml.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、スクリプトを含んでいる安全でない可能性があります。
+org.hibernate.validator.constraints.ScriptAssert.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、スクリプトの式"{script}"がtrueを返しませんでした。
+org.hibernate.validator.constraints.URL.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、不正なURLの形式です。
 
-org.hibernate.validator.constraints.br.CNPJ.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u6cd5\u4eba\u7a0e\u91d1\u652f\u6255\u756a\u53f7\uff08CNPJ\uff09\u3068\u3057\u3066\u4e0d\u6b63\u306a\u66f8\u5f0f\u3067\u3059\u3002
-org.hibernate.validator.constraints.br.CPF.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u500b\u4eba\u7a0e\u91d1\u652f\u6255\u3044\u756a\u53f7\uff08CPF\uff09\u3068\u3057\u3066\u4e0d\u6b63\u306a\u66f8\u5f0f\u3067\u3059\u3002
-org.hibernate.validator.constraints.br.TituloEleitor.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001ID\u30ab\u30fc\u30c9\u3068\u3057\u3066\u4e0d\u6b63\u306a\u66f8\u5f0f\u3067\u3059\u3002
+org.hibernate.validator.constraints.br.CNPJ.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、法人税金支払番号（CNPJ）として不正な書式です。
+org.hibernate.validator.constraints.br.CPF.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、個人税金支払い番号（CPF）として不正な書式です。
+org.hibernate.validator.constraints.br.TituloEleitor.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、IDカードとして不正な書式です。
 
-org.hibernate.validator.constraints.Currency.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u901a\u8ca8({value})\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+org.hibernate.validator.constraints.Currency.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、通貨({value})として不正です。
 
-org.hibernate.validator.constraints.pl.REGON.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001\u30dd\u30fc\u30e9\u30f3\u30c9\u7d0d\u7a0e\u8005\u8eab\u5206\u8a3c\u756a\u53f7(REGON)\u3068\u3057\u3066\u4e0d\u6b63\u306a\u66f8\u5f0f\u3067\u3059\u3002
-org.hibernate.validator.constraints.pl.NIP.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001VAT\u8eab\u5206\u8a3c\u756a\u53f7(NIP)\u3068\u3057\u3066\u4e0d\u6b63\u306a\u66f8\u5f0f\u3067\u3059\u3002
-org.hibernate.validator.constraints.pl.PESEL.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001 \u30dd\u30fc\u30e9\u30f3\u30c9\u56fd\u969b\u8eab\u5206\u8a3c\u756a\u53f7(PESEL)\u3068\u3057\u3066\u4e0d\u6b63\u306a\u66f8\u5f0f\u3067\u3059\u3002
+org.hibernate.validator.constraints.pl.REGON.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、ポーランド納税者身分証番号(REGON)として不正な書式です。
+org.hibernate.validator.constraints.pl.NIP.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、VAT身分証番号(NIP)として不正な書式です。
+org.hibernate.validator.constraints.pl.PESEL.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、 ポーランド国際身分証番号(PESEL)として不正な書式です。
 
-# Hibernate Validator 6.0\u306e\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8
-org.hibernate.validator.constraints.time.DurationMax.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${days == 0 ? '' : days == 1 ? ' 1 day' : days += '\u65e5'}${hours == 0 ? '' : hours == 1 ? ' 1 hour' : ' ' += hours += '\u6642'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minute' : ' ' += minutes += ' \u5206'}${seconds == 0 ? '' : seconds == 1 ? ' 1 second' : ' ' += seconds += ' \u79d2'}${millis == 0 ? '' : millis == 1 ? ' 1 milli' : ' ' += millis += ' \u30df\u30ea\u79d2'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' \u30ca\u30ce\u79d2'} ${inclusive == true ? ' \u4ee5\u524d' : '\u3088\u308a\u524d'}\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-org.hibernate.validator.constraints.time.DurationMin.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${empty(printer) ? validatedValue : printer.print(validatedValue)}\uff09\u306f\u3001${days == 0 ? '' : days == 1 ? ' 1 day' : days += '\u65e5'}${hours == 0 ? '' : hours == 1 ? ' 1 hour' : ' ' += hours += '\u6642'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minute' : ' ' += minutes += ' \u5206'}${seconds == 0 ? '' : seconds == 1 ? ' 1 second' : ' ' += seconds += ' \u79d2'}${millis == 0 ? '' : millis == 1 ? ' 1 milli' : ' ' += millis += ' \u30df\u30ea\u79d2'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' \u30ca\u30ce\u79d2'} ${inclusive == true ? ' \u4ee5\u964d' : '\u3088\u308a\u5f8c'}\u3092\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+# Hibernate Validator 6.0のエラーメッセージ
+org.hibernate.validator.constraints.time.DurationMax.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${days == 0 ? '' : days == 1 ? ' 1 day' : days += '日'}${hours == 0 ? '' : hours == 1 ? ' 1 hour' : ' ' += hours += '時'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minute' : ' ' += minutes += ' 分'}${seconds == 0 ? '' : seconds == 1 ? ' 1 second' : ' ' += seconds += ' 秒'}${millis == 0 ? '' : millis == 1 ? ' 1 milli' : ' ' += millis += ' ミリ秒'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' ナノ秒'} ${inclusive == true ? ' 以前' : 'より前'}を設定してください。
+org.hibernate.validator.constraints.time.DurationMin.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、${days == 0 ? '' : days == 1 ? ' 1 day' : days += '日'}${hours == 0 ? '' : hours == 1 ? ' 1 hour' : ' ' += hours += '時'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minute' : ' ' += minutes += ' 分'}${seconds == 0 ? '' : seconds == 1 ? ' 1 second' : ' ' += seconds += ' 秒'}${millis == 0 ? '' : millis == 1 ? ' 1 milli' : ' ' += millis += ' ミリ秒'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' ナノ秒'} ${inclusive == true ? ' 以降' : 'より後'}を設定してください。
 
 
 

--- a/src/test/java/com/github/mygreen/supercsv/builder/GeneralProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/GeneralProcessorBuilderTest.java
@@ -41,6 +41,7 @@ import com.github.mygreen.supercsv.cellprocessor.format.TextParseException;
 import com.github.mygreen.supercsv.cellprocessor.format.TextPrintException;
 import com.github.mygreen.supercsv.exception.SuperCsvInvalidAnnotationException;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -70,7 +71,7 @@ public class GeneralProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         
     }
     

--- a/src/test/java/com/github/mygreen/supercsv/builder/ProcesssorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/ProcesssorBuilderTest.java
@@ -24,6 +24,7 @@ import org.supercsv.exception.SuperCsvConstraintViolationException;
 
 import com.github.mygreen.supercsv.annotation.CsvBean;
 import com.github.mygreen.supercsv.annotation.CsvColumn;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -54,7 +55,7 @@ public class ProcesssorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     @CsvBean

--- a/src/test/java/com/github/mygreen/supercsv/builder/joda/DateTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/joda/DateTimeProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class DateTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ssZZ";

--- a/src/test/java/com/github/mygreen/supercsv/builder/joda/LocalDateProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/joda/LocalDateProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class LocalDateProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd";

--- a/src/test/java/com/github/mygreen/supercsv/builder/joda/LocalDateTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/joda/LocalDateTimeProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class LocalDateTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/joda/LocalTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/joda/LocalTimeProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class LocalTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/joda/MonthDayProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/joda/MonthDayProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class MonthDayProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "MM-dd";

--- a/src/test/java/com/github/mygreen/supercsv/builder/joda/YearMonthProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/joda/YearMonthProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class YearMonthProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/BigDecimalProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/BigDecimalProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class BigDecimalProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_FORMATTED_PATTERN = "#,###.0##";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/BigIntegerProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/BigIntegerProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class BigIntegerProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_FORMATTED_PATTERN = "#,###";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/BooleanProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/BooleanProcessorBuilderTest.java
@@ -24,6 +24,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -60,7 +61,7 @@ public class BooleanProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final Boolean TEST_VALUE_TRUE_OBJ = Boolean.TRUE;
@@ -675,7 +676,7 @@ public class BooleanProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final boolean TEST_VALUE_PRIMITIVE_INIT_OBJ = false;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/ByteProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/ByteProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -59,7 +60,7 @@ public class ByteProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final String TEST_FORMATTED_PATTERN = "#,###";
@@ -431,7 +432,7 @@ public class ByteProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final byte TEST_VALUE_PRIMITIVE_INIT_OBJ = (byte)0;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/CalendarProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/CalendarProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.util.Utils;
@@ -53,7 +54,7 @@ public class CalendarProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/CharacterProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/CharacterProcessorBuilderTest.java
@@ -28,6 +28,7 @@ import com.github.mygreen.supercsv.builder.FieldAccessor;
 import com.github.mygreen.supercsv.cellprocessor.format.TextFormatter;
 import com.github.mygreen.supercsv.cellprocessor.format.TextParseException;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -165,7 +166,7 @@ public class CharacterProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final Character TEST_VALUE_1_OBJ = toCharacter("a");
@@ -266,7 +267,7 @@ public class CharacterProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final char TEST_VALUE_PRIMITIVE_INIT_OBJ = '\u0000';

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/DateProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/DateProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class DateProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/DoubleProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/DoubleProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -59,7 +60,7 @@ public class DoubleProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final String TEST_FORMATTED_PATTERN = "#,###.0#";
@@ -431,7 +432,7 @@ public class DoubleProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final double TEST_VALUE_PRIMITIVE_INIT_OBJ = 0.0d;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/EnumProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/EnumProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class EnumProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     public enum TestEnum {

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/FloatProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/FloatProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -59,7 +60,7 @@ public class FloatProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final String TEST_FORMATTED_PATTERN = "#,###.0#";
@@ -431,7 +432,7 @@ public class FloatProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final float TEST_VALUE_PRIMITIVE_INIT_OBJ = 0.0f;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/IntegerProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/IntegerProcessorBuilderTest.java
@@ -24,6 +24,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -60,7 +61,7 @@ public class IntegerProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final String TEST_FORMATTED_PATTERN = "#,###";
@@ -781,7 +782,7 @@ public class IntegerProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final int TEST_VALUE_PRIMITIVE_INIT_OBJ = 0;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/LongProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/LongProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -59,7 +60,7 @@ public class LongProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final String TEST_FORMATTED_PATTERN = "#,###";
@@ -431,7 +432,7 @@ public class LongProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final long TEST_VALUE_PRIMITIVE_INIT_OBJ = 0l;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/ShortProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/ShortProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -59,7 +60,7 @@ public class ShortProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final String TEST_FORMATTED_PATTERN = "#,###";
@@ -431,7 +432,7 @@ public class ShortProcessorBuilderTest {
             this.beanMappingFactory = new BeanMappingFactory();
             this.exceptionConverter = new CsvExceptionConverter();
             
-            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+            this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         }
         
         private static final short TEST_VALUE_PRIMITIVE_INIT_OBJ = (short)0;

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/SqlDateProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/SqlDateProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class SqlDateProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/TimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/TimeProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class TimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/standard/TimestampProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/standard/TimestampProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class TimestampProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/LocalDateProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/LocalDateProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class LocalDateProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "uuuu-MM-dd";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/LocalDateTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/LocalDateTimeProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class LocalDateTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "uuuu-MM-dd HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/LocalTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/LocalTimeProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class LocalTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "HH:mm:ss";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/MonthDayProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/MonthDayProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class MonthDayProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "MM-dd";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/OffsetDateTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/OffsetDateTimeProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class OffsetDateTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "uuuu-MM-dd HH:mm:ssxxx";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/OffsetTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/OffsetTimeProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class OffsetTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "HH:mm:ssxxx";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/YearMonthProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/YearMonthProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class YearMonthProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "uuuu-MM";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/YearProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/YearProcessorBuilderTest.java
@@ -22,6 +22,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -50,7 +51,7 @@ public class YearProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "uuuu";

--- a/src/test/java/com/github/mygreen/supercsv/builder/time/ZonedDateTimeProcessorBuilderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/builder/time/ZonedDateTimeProcessorBuilderTest.java
@@ -23,6 +23,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.exception.SuperCsvValidationException;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
@@ -51,7 +52,7 @@ public class ZonedDateTimeProcessorBuilderTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     }
     
     private static final String TEST_DEFAULT_PATTERN = "uuuu-MM-dd HH:mm:ssxxx'['VV']'";

--- a/src/test/java/com/github/mygreen/supercsv/validation/CsvValidatorTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/validation/CsvValidatorTest.java
@@ -24,6 +24,7 @@ import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
 import com.github.mygreen.supercsv.io.CsvAnnotationBeanReader;
 import com.github.mygreen.supercsv.io.CsvAnnotationBeanWriter;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
 
@@ -38,7 +39,7 @@ public class CsvValidatorTest  {
     
     private BeanMappingFactory beanMappingFactory;
     private CsvExceptionConverter exceptionConverter;
-    private MessageResolver testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+    private MessageResolver testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidatorTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidatorTest.java
@@ -27,6 +27,7 @@ import com.github.mygreen.supercsv.annotation.CsvBean;
 import com.github.mygreen.supercsv.annotation.CsvColumn;
 import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
+import com.github.mygreen.supercsv.localization.EncodingControl;
 import com.github.mygreen.supercsv.localization.MessageInterpolator;
 import com.github.mygreen.supercsv.localization.MessageResolver;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
@@ -63,7 +64,7 @@ public class CsvBeanValidatorTest {
         this.beanMappingFactory = new BeanMappingFactory();
         this.exceptionConverter = new CsvExceptionConverter();
         
-        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages"));
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
         this.messageInterpolator = new MessageInterpolator();
         
         this.csvValidator = new CsvBeanValidator();

--- a/src/test/resources/TestMessages.properties
+++ b/src/test/resources/TestMessages.properties
@@ -1,90 +1,90 @@
 #############################################
-# \u30c6\u30b9\u30c8\u7528\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306e\u5b9a\u7fa9
+# テスト用のメッセージの定義
 #############################################
 
-name=\u540d\u524d
-age=\u5e74\u9f62
+name=名前
+age=年齢
 
-## \u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u306e\u8a2d\u5b9a\u5024
-nullRead.value1=\u3042\u3044\u3046
-nullRead.value2=\u304b\u304d\u304f
+## アノテーションの設定値
+nullRead.value1=あいう
+nullRead.value2=かきく
 
-defaultRead.value.string=\u3042\u3044\u3046
+defaultRead.value.string=あいう
 defaultRead.value.int=1,234
 
-defaultWrite.value.string=\u3042\u3044\u3046
+defaultWrite.value.string=あいう
 defaultWrite.value.int=1,234
 
 
 
-# \u30d1\u30fc\u30b9\u30a8\u30e9\u30fc\u6642\u306e\u30e1\u30c3\u30bb\u30fc\u30b8
-#typeMismatch={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306e\u66f8\u5f0f\u306f\u4e0d\u6b63\u3067\u3059\u3002
+# パースエラー時のメッセージ
+#typeMismatch={csvContext} : 項目「{label}」の値（{validatedValue}）の書式は不正です。
 
-typeMismatch.boolean={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001true\u306e\u5024\u300c${f:join(trueValues, ', ')}\u300d\u3001\u307e\u305f\u306ffalse\u306e\u5024\u300c${f:join(falseValues, ', ')}\u300d\u306e\u4f55\u308c\u304b\u306e\u5024\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+typeMismatch.boolean={csvContext} : 項目「{label}」の値（{validatedValue}）は、trueの値「${f:join(trueValues, ', ')}」、またはfalseの値「${f:join(falseValues, ', ')}」の何れかの値で設定してください。
 typeMismatch.java.lang.Boolean={typeMismatch.boolean}
 
-typeMismatch.char={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u3001\u7a7a\u6587\u5b57\u3067\u3042\u308b\u305f\u3081\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.char={csvContext} : 項目「{label}」の値は、空文字であるため不正です。
 typeMismatch.java.lang.Character={typeMismatch.char}
 
-typeMismatch.java.lang.Number={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6570\u5024\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.byte={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.lang.Number={csvContext} : 項目「{label}」の値（{validatedValue}）は、数値の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.byte={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 typeMismatch.java.lang.Byte={typeMismatch.byte}
-typeMismatch.short={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.short={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 typeMismatch.java.lang.Short={typeMismatch.short}
-typeMismatch.int={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.int={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 typeMismatch.java.lang.Integer={typeMismatch.int}
-typeMismatch.long={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.long={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 typeMismatch.java.lang.Long={typeMismatch.long}
-typeMismatch.float={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5c0f\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.float={csvContext} : 項目「{label}」の値（{validatedValue}）は、小数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 typeMismatch.java.lang.Float={typeMismatch.float}
-typeMismatch.double={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5c0f\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.double={csvContext} : 項目「{label}」の値（{validatedValue}）は、小数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 typeMismatch.java.lang.Double={typeMismatch.double}
 
-typeMismatch.java.math.BigDecimal={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6570\u5024\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.math.BigInteger={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.math.BigDecimal={csvContext} : 項目「{label}」の値（{validatedValue}）は、数値の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.java.math.BigInteger={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
 
-typeMismatch.java.lang.Enum={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u4f55\u308c\u304b\u306e\u5024\u300c${f:join(enums, ', ')}\u300d\u3067\u3042\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002
+typeMismatch.java.lang.Enum={csvContext} : 項目「{label}」の値（{validatedValue}）は、何れかの値「${f:join(enums, ', ')}」である必要があります。
 
-typeMismatch.java.util.Date={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.util.Calendar={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.sql.Date={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u4ed8\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.sql.Time={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.sql.Timestamp={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u30bf\u30a4\u30e0\u30b9\u30bf\u30f3\u30d7\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.util.Date={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.java.util.Calendar={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.java.sql.Date={csvContext} : 項目「{label}」の値（{validatedValue}）は、日付の書式「{pattern}」として不正です。
+typeMismatch.java.sql.Time={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
+typeMismatch.java.sql.Timestamp={csvContext} : 項目「{label}」の値（{validatedValue}）は、タイムスタンプの書式「{pattern}」として不正です。
 
-typeMismatch.java.time.LocalDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.LocalDate={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u4ed8\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.LocalTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.ZonedDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.OffsetDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.OffsetTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.Year={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5e74\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.YearMonth={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5e74\u6708\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.java.time.MonthDay={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6708\u65e5\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.LocalDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.java.time.LocalDate={csvContext} : 項目「{label}」の値（{validatedValue}）は、日付の書式「{pattern}」として不正です。
+typeMismatch.java.time.LocalTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
+typeMismatch.java.time.ZonedDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.java.time.OffsetDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.java.time.OffsetTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
+typeMismatch.java.time.Year={csvContext} : 項目「{label}」の値（{validatedValue}）は、年の書式「{pattern}」として不正です。
+typeMismatch.java.time.YearMonth={csvContext} : 項目「{label}」の値（{validatedValue}）は、年月の書式「{pattern}」として不正です。
+typeMismatch.java.time.MonthDay={csvContext} : 項目「{label}」の値（{validatedValue}）は、月日の書式「{pattern}」として不正です。
 
-typeMismatch.org.joda.time.LocalDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.org.joda.time.LocalDate={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u4ed8\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.org.joda.time.LocalTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.org.joda.time.DateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.org.joda.time.YearMonth={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5e74\u6708\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-typeMismatch.org.joda.time.MonthDay={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6708\u65e5\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-
-
-# \u72ec\u81ea\u306e\u30af\u30e9\u30b9\u30bf\u30a4\u30d7
-typeMismatch.com.github.mygreen.supercsv.builder.GeneralProcessorBuilderTest$SampleObject={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u3001XML\u306e\u5024\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.org.joda.time.LocalDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.org.joda.time.LocalDate={csvContext} : 項目「{label}」の値（{validatedValue}）は、日付の書式「{pattern}」として不正です。
+typeMismatch.org.joda.time.LocalTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
+typeMismatch.org.joda.time.DateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
+typeMismatch.org.joda.time.YearMonth={csvContext} : 項目「{label}」の値（{validatedValue}）は、年月の書式「{pattern}」として不正です。
+typeMismatch.org.joda.time.MonthDay={csvContext} : 項目「{label}」の値（{validatedValue}）は、月日の書式「{pattern}」として不正です。
 
 
-# \u72ec\u81ea\u306e\u30e1\u30c3\u30bb\u30fc\u30b8
-fieldError.max={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${printer.print(validatedValue)}\uff09\u306f\u3001${printer.print(max)}\u4ee5\u5185\u3067\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-age.required={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306f\u3001\u5e74\u9f62\u304c{maxAge}\u6b73\u4ee5\u4e0a\u306e\u5834\u5408\u306b\u306f\u5fc5\u9808\u3067\u3059\u3002
-
-# Spring\u7528\u306e\u30c6\u30b9\u30c8\u3067\u306e\u72ec\u81ea\u306e\u30af\u30e9\u30b9\u30bf\u30a4\u30d7
-com.github.mygreen.supercsv.builder.spring.CsvUserNameExist.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5b58\u5728\u3057\u307e\u305b\u3093\u3002
-typeMismatch.SampleCsv.homepage={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001URL\u306e\u66f8\u5f0f\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
-fieldError.homepage.supportedProtocol={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306e\u30d7\u30ed\u30c8\u30b3\u30eb\u300c{protocol}\u300d\u306f\u30b5\u30dd\u30fc\u30c8\u3057\u3066\u3044\u307e\u305b\u3093\u3002
-com.github.mygreen.supercsv.builder.spring.UserMailPattern.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u30e1\u30fc\u30eb\u30a2\u30c9\u30ec\u30b9\u306e\u66f8\u5f0f\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+# 独自のクラスタイプ
+typeMismatch.com.github.mygreen.supercsv.builder.GeneralProcessorBuilderTest$SampleObject={csvContext} : 項目「{label}」の値は、XMLの値として不正です。
 
 
-ParseInt={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+# 独自のメッセージ
+fieldError.max={csvContext} : 項目「{label}」の値（${printer.print(validatedValue)}）は、${printer.print(max)}以内で入力してください。
+age.required={csvContext} : 項目「{label}」は、年齢が{maxAge}歳以上の場合には必須です。
+
+# Spring用のテストでの独自のクラスタイプ
+com.github.mygreen.supercsv.builder.spring.CsvUserNameExist.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、存在しません。
+typeMismatch.SampleCsv.homepage={csvContext} : 項目「{label}」の値（{validatedValue}）は、URLの書式として不正です。
+fieldError.homepage.supportedProtocol={csvContext} : 項目「{label}」の値（{validatedValue}）のプロトコル「{protocol}」はサポートしていません。
+com.github.mygreen.supercsv.builder.spring.UserMailPattern.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、メールアドレスの書式として不正です。
+
+
+ParseInt={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数として不正です。
 
 
 


### PR DESCRIPTION
- #30 の対応
- ResouceBundleで読み込むプロパティファイルの文字コードをUTF-8に変更。
  - ``EncodingControl`` で文字コードを指定するよう全体を修正。
- クラスパスのルートにおいている ``SuperCsvMessages.properties`` も、asciiコード変換なし、文字コードUTF-8固定となり、互換性がなくなるため、注意が必要。