### PR TITLE
ビルド関連のライブラリをアップデート

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,13 @@ CSVのJavaライブラリであるSuperCSVに、アノテーション機能を�
 		<url>https://github.com/mygreen/super-csv-annotation</url>
 	</scm>
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
-
 	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
 		<repository>
-			<id>sonatype-nexus-staging</id>
-			<name>Maven Central Repository</name>
+			<id>ossrh</id>
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
@@ -302,14 +299,15 @@ $(document).ready(function() {
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
 				<configuration>
-					<argLine>${jacocoArgs}</argLine>
+					<argLine>${jacocoArgs} -Duser.language=ja -Duser.country=JP</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
 		        <groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.9</version>
+				<version>0.8.5</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -329,23 +327,21 @@ $(document).ready(function() {
 			<plugin>
 				<groupId>org.sonarsource.scanner.maven</groupId>
 				<artifactId>sonar-maven-plugin</artifactId>
-				<version>3.4.1.1168</version>
+				<version>3.7.0.1746</version>
 			</plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>3.1.5</version>
+				<version>4.2.0</version>
 				<dependencies>
-					<!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
 					<dependency>
 						<groupId>com.github.spotbugs</groupId>
 						<artifactId>spotbugs</artifactId>
-						<version>3.1.5</version>
+						<version>4.2.1</version>
 					</dependency>
 				</dependencies>
 			</plugin>
 			<plugin>
-				<!-- pgp -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<executions>
@@ -358,7 +354,17 @@ $(document).ready(function() {
 					</execution>
 				</executions>
 			</plugin>
-
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.13</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<repositories>
@@ -540,6 +546,7 @@ $(document).ready(function() {
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
+				<version>3.2.0</version>
 				<configuration>
 					<aggregate>true</aggregate>
 					<inputEncoding>UTF-8</inputEncoding>


### PR DESCRIPTION
GitHub Actions でビルドが成功するよう、ビルド関連のライブラリのバージョンをアップデート。

- SonarType
- Junit関連のレポート
  - JaCoCo
  - SpotBugs
 