### PR TITLE
読み込み処理／書き込み処理時のメソッドとしてイベントハンドラを指定可能なメソッドを追加/Streamを返すメソッドを追加

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/io/AbstractCsvAnnotationBeanReader.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/AbstractCsvAnnotationBeanReader.java
@@ -39,6 +39,7 @@ import com.github.mygreen.supercsv.validation.ValidationContext;
  * @param <T> マッピング対象のBeanのクラスタイプ
  *
  * @see CsvBeanReader
+ * @version 2.3
  * @since 2.1
  * @author T.TSUCHIE
  *
@@ -141,6 +142,34 @@ public abstract class AbstractCsvAnnotationBeanReader<T> extends AbstractCsvRead
         
         return null; // EOF
         
+        
+    }
+    
+    /**
+     * 成功時、例外発生時の処理を指定して、1レコード分を読み込みます。
+     * 
+     * @since 2.3
+     * @param successHandler 読み込み成功時の処理の実装。
+     * @param errorHandler CSVに関する例外発生時の処理の実装。
+     * @return CSVの読み込み処理ステータスを返します。
+     * @throws IOException 致命的なレコードの読み込みに失敗した場合にスローされます。
+     */
+    public CsvReadStatus read(final CsvSuccessHandler<T> successHandler, final CsvErrorHandler errorHandler) throws IOException {
+        
+        try {
+            final T bean = read();
+            if(bean != null) {
+                successHandler.onSuccess(bean);
+                return CsvReadStatus.SUCCESS;
+            } else {
+                return CsvReadStatus.EOF;
+            }
+        
+        } catch(SuperCsvException e) {
+            errorHandler.onError(e);
+            return CsvReadStatus.ERROR;
+            
+        }
         
     }
     

--- a/src/main/java/com/github/mygreen/supercsv/io/AbstractCsvAnnotationBeanReader.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/AbstractCsvAnnotationBeanReader.java
@@ -2,12 +2,19 @@ package com.github.mygreen.supercsv.io;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.exception.SuperCsvCellProcessorException;
@@ -171,6 +178,53 @@ public abstract class AbstractCsvAnnotationBeanReader<T> extends AbstractCsvRead
             
         }
         
+    }
+    
+    /**
+     * {@link Stream} を返します。要素はCSVの行をBeanにマッピングしたオブジェクトです。
+     * <p>読み込む際には例外 {@link SuperCsvException} / {@link UncheckedIOException} が発生する可能性があります（読み込みを行った {@link Stream} メソッドからスローされます)。</p>
+     * <p>読み込み時にスローされた {@link IOException} は、{@link UncheckedIOException} にラップされます。</p>
+     * 
+     * @since 2.3
+     * @return 各レコードをBeanに変換した {@link Stream} を返します。
+     */
+    public Stream<T> lines() {
+        
+        Iterator<T> itr = new Iterator<T>() {
+            
+            T nextLine = null;
+            
+            @Override
+            public boolean hasNext() {
+                if(nextLine != null) {
+                    return true;
+                    
+                } else {
+                    try {
+                        nextLine = read();
+                        return (nextLine != null);
+                    } catch(IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            }
+
+            @Override
+            public T next() {
+                if (nextLine != null || hasNext()) {
+                    T line = nextLine;
+                    nextLine = null;
+                    return line;
+                } else {
+                    throw new NoSuchElementException();
+                }
+            }
+            
+        };
+        
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                itr, Spliterator.ORDERED | Spliterator.NONNULL), false);
+
     }
     
     /**

--- a/src/main/java/com/github/mygreen/supercsv/io/AbstractCsvAnnotationBeanWriter.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/AbstractCsvAnnotationBeanWriter.java
@@ -37,6 +37,7 @@ import com.github.mygreen.supercsv.validation.ValidationContext;
  * @param <T> マッピング対象のBeanのクラスタイプ
  * 
  * @see CsvBeanWriter
+ * @version 2.3
  * @since 2.1
  * @author T.TSUCHIE
  *
@@ -142,6 +143,29 @@ public abstract class AbstractCsvAnnotationBeanWriter<T> extends AbstractCsvWrit
         
         // エラーメッセージの変換
         processErrors(bindingErrors, context, rowException);
+        
+    }
+    
+    /**
+     * 例外発生時の処理を指定して、1レコード分を書き込みます。
+     * 
+     * @since 2.3
+     * @param source 書き込むレコードのデータ。
+     * @param errorHandler  CSVに関する例外発生時の処理の実装。
+     * @return CSVの書き込み処理ステータスを返します。
+     * @throws IOException
+     */
+    public CsvWriteStatus write(final T source, final CsvErrorHandler errorHandler) throws IOException {
+        
+        try {
+            write(source);
+            return CsvWriteStatus.SUCCESS;
+            
+        } catch(SuperCsvException e) {
+            errorHandler.onError(e);
+            return CsvWriteStatus.ERROR;
+            
+        }
         
     }
     

--- a/src/main/java/com/github/mygreen/supercsv/io/CsvErrorHandler.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/CsvErrorHandler.java
@@ -1,0 +1,36 @@
+package com.github.mygreen.supercsv.io;
+
+import org.supercsv.exception.SuperCsvException;
+
+/**
+ * CSV処理に失敗したときの戦略。
+ *
+ * @since 2.3
+ * @author T.TSUCHIE
+ *
+ */
+@FunctionalInterface
+public interface CsvErrorHandler {
+    
+    /**
+     * 例外発生時に何も行わない実装を取得します。
+     * <p>例外を無視して続けて処理したい場合に利用します。
+     * @return 空の実装を返します。
+     */
+    static CsvErrorHandler empty() {
+        return new CsvErrorHandler() {
+
+            @Override
+            public void onError(SuperCsvException exception) {
+                // ignore error
+            }
+            
+        };
+    }
+    
+    /**
+     * CSV処理に失敗したときに呼び出される処理です。
+     * @param exception 発生したCSVに関する例外
+     */
+    void onError(SuperCsvException exception);
+}

--- a/src/main/java/com/github/mygreen/supercsv/io/CsvReadStatus.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/CsvReadStatus.java
@@ -1,0 +1,26 @@
+package com.github.mygreen.supercsv.io;
+
+
+/**
+ * CSVの読み込み処理ステータスを表現する列挙型です。
+ *
+ * @since 2.3
+ * @author T.TSUCHIE
+ *
+ */
+public enum CsvReadStatus {
+    
+    /**
+     * 読み込み時にCSVファイルを最後まで読み込んだとき。
+     */
+    EOF,
+    /**
+     * 読み込み/書き込み処理に成功したとき。
+     */
+    SUCCESS,
+    /**
+     * 読み込み/書き込み処理に失敗したとき。
+     */
+    ERROR;
+    
+}

--- a/src/main/java/com/github/mygreen/supercsv/io/CsvSuccessHandler.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/CsvSuccessHandler.java
@@ -1,0 +1,20 @@
+package com.github.mygreen.supercsv.io;
+
+
+/**
+ * CSV処理に成功したときの戦略。
+ *
+ * @since 2.3
+ * @author T.TSUCHIE
+ * 
+ * @param <T> マッピング対象のBeanのクラスタイプ
+ */
+@FunctionalInterface
+public interface CsvSuccessHandler<T> {
+    
+    /**
+     * CSVの行に対する処理が正常に行われたときに呼び出されます。
+     * @param record CSVの行をマッピングしたBeanオブジェクト。
+     */
+    void onSuccess(T record);
+}

--- a/src/main/java/com/github/mygreen/supercsv/io/CsvWriteStatus.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/CsvWriteStatus.java
@@ -1,0 +1,22 @@
+package com.github.mygreen.supercsv.io;
+
+
+/**
+ * CSVの書き込み処理ステータスを表現する列挙型です。
+ *
+ * @since 2.3
+ * @author T.TSUCHIE
+ *
+ */
+public enum CsvWriteStatus {
+    
+    /**
+     * 書き込み処理に成功したとき。
+     */
+    SUCCESS,
+    /**
+     * 書き込み処理に失敗したとき。
+     */
+    ERROR;
+    
+}

--- a/src/test/java/com/github/mygreen/supercsv/io/LazyCsvAnnotationBeanWriterTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/io/LazyCsvAnnotationBeanWriterTest.java
@@ -1,17 +1,12 @@
 package com.github.mygreen.supercsv.io;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
 import static com.github.mygreen.supercsv.tool.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +24,7 @@ import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
 /**
  * {@link LazyCsvAnnotationBeanWriter}のテスタ
  *
+ * @version 2.3
  * @since 2.1
  * @author T.TSUCHIE
  *
@@ -661,6 +657,44 @@ public class LazyCsvAnnotationBeanWriterTest {
         System.out.println(actual);
         
         String expected = getTextFromFile("src/test/data/test_write_lazy_fixedColumn_noSetHeader.csv", Charset.forName("UTF-8"));
+        assertThat(actual).isEqualTo(expected);
+        
+        assertThat(csvWriter.getErrorMessages()).hasSize(0);
+        
+        csvWriter.close();
+        
+    }
+    
+    /**
+     * 全て書き出す - 初期化は自動的に行う。
+     */
+    @Test
+    public void testWrite_withHandler_normal() throws Exception {
+        
+        // テストデータの作成
+        final List<SampleLazyBean> list = createNormalData();
+        
+        StringWriter strWriter = new StringWriter();
+        
+        LazyCsvAnnotationBeanWriter<SampleLazyBean> csvWriter = new LazyCsvAnnotationBeanWriter<>(
+                SampleLazyBean.class,
+                strWriter,
+                CsvPreference.STANDARD_PREFERENCE);
+        
+        
+        csvWriter.init("no", "name", "生年月日", "備考");
+        csvWriter.writeHeader();
+        csvWriter.flush();
+        
+        for(SampleLazyBean item : list) {
+            csvWriter.write(item, error -> fail(error.getMessage()));
+            csvWriter.flush();
+        }
+        
+        String actual = strWriter.toString();
+        System.out.println(actual);
+        
+        String expected = getTextFromFile("src/test/data/test_write_lazy_setHeader.csv", Charset.forName("UTF-8"));
         assertThat(actual).isEqualTo(expected);
         
         assertThat(csvWriter.getErrorMessages()).hasSize(0);


### PR DESCRIPTION
- 読み込み時に/書き込み時にイベントハンドラを指定して処理できるメソッドを追加。
  - エラー処理をtry-catch不要で処理可能にする。
- 読み込み時にStreamを返すメソッドを追加