### PR TITLE
MessageInterpolator に再帰的評価対象外の設定を追加

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/cellprocessor/constraint/PatternFactory.java
+++ b/src/main/java/com/github/mygreen/supercsv/cellprocessor/constraint/PatternFactory.java
@@ -39,7 +39,7 @@ public class PatternFactory implements ConstraintProcessorFactory<CsvPattern> {
                     .varWithAnno("anno", anno.annotationType())
                     .var("attrName", "regex")
                     .var("attrValue", anno.regex())
-                    .var("type", "{key.regex}")
+                    .var("type", MessageBuilder.create("key.regex").format())
                     .format(true));
         }
         

--- a/src/main/java/com/github/mygreen/supercsv/cellprocessor/conversion/RegexReplaceFactory.java
+++ b/src/main/java/com/github/mygreen/supercsv/cellprocessor/conversion/RegexReplaceFactory.java
@@ -41,7 +41,7 @@ public class RegexReplaceFactory implements ConversionProcessorFactory<CsvRegexR
                     .varWithAnno("anno", anno.annotationType())
                     .var("attrName", "regex")
                     .var("attrValue", anno.regex())
-                    .var("type", "{key.regex}")
+                    .var("type", MessageBuilder.create("key.regex").format())
                     .format(true));
         }
         

--- a/src/main/java/com/github/mygreen/supercsv/localization/MessageBuilder.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/MessageBuilder.java
@@ -102,6 +102,12 @@ public class MessageBuilder {
         return MESSAGE_INTERPOLATOR.interpolate(message, vars, recusrsive, MESSAGE_RESOLVER);
     }
     
+    /**
+     * メッセージの組み立てを開始します。
+     * 
+     * @param code メッセージコード。
+     * @return メッセージを組み立てるためのクラス。
+     */
     public static MessageBuilder create(final String code) {
         
         return new MessageBuilder(code);

--- a/src/main/java/com/github/mygreen/supercsv/localization/MessageInterpolator.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/MessageInterpolator.java
@@ -244,11 +244,10 @@ public class MessageInterpolator {
      * @param recursive 再帰的に処理するかどうか。
      * @param maxRecursion 最大再帰回数
      * @param currentDepth 再帰回数
-     * @param expression 再帰対象のメッセージ
+     * @param expression 再帰対象の式
      * @return 最大再帰回数を超えていなければfalseを返す。
      */
-    private boolean recursivable(final boolean recursive, final int maxRecursion, final int currentDepth,
-            String message) {
+    private boolean recursivable(final boolean recursive, final int maxRecursion, final int currentDepth, final String expression) {
 
         if(!recursive) {
             return false;
@@ -263,7 +262,7 @@ public class MessageInterpolator {
             return true;
         }
 
-        logger.warn("Over recursive depth : currentDepth={}, maxDepth={}, message={}.", currentDepth, maxRecursion, message);
+        logger.warn("Over recursive depth : currentDepth={}, maxDepth={}, expression={}.", currentDepth, maxRecursion, expression);
 
         return false;
 

--- a/src/main/java/com/github/mygreen/supercsv/localization/MessageInterpolator.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/MessageInterpolator.java
@@ -24,6 +24,7 @@ import com.github.mygreen.supercsv.util.StackUtils;
  * <p>{@link MessageResolver}を指定した場合、メッセージ中の変数<code>{...}</code>をメッセージ定義コードとして解決する。
  *    ただし、メッセージ変数で指定されている変数が優先される。
  * 
+ * @version 2.4
  * @since 2.0
  * @author T.TSUCHIE
  *
@@ -33,6 +34,21 @@ public class MessageInterpolator {
     private static final Logger logger = LoggerFactory.getLogger(MessageInterpolator.class);
     
     private ExpressionLanguage expressionLanguage;
+    
+    /**
+     * EL式を再帰的に評価するかどうか。
+     */
+    private boolean recursiveForEl = false;
+    
+    /**
+     * 変数を再帰的に評価するかどうか。
+     */
+    private boolean recursiveForVar = false;
+    
+    /**
+     * 再帰処理の最大回数
+     */
+    private int maxRecursiveDepth = 5;
     
     /**
      * デフォルトのコンストラクタ
@@ -72,7 +88,7 @@ public class MessageInterpolator {
      * @return 補完したメッセージ。
      */
     public String interpolate(final String message, final Map<String, ?> vars, boolean recursive) {
-        return parse(message, vars, recursive, null);
+        return parse(message, vars, recursive, 0, null);
     }
     
     /**
@@ -87,7 +103,7 @@ public class MessageInterpolator {
      */
     public String interpolate(final String message, final Map<String, ?> vars, boolean recursive,
             final MessageResolver messageResolver) {
-        return parse(message, vars, recursive, messageResolver);
+        return parse(message, vars, recursive, 0, messageResolver);
     }
     
     /**
@@ -95,10 +111,12 @@ public class MessageInterpolator {
      * @param message 対象のメッセージ。
      * @param vars メッセージ中の変数に対する値のマップ。
      * @param recursive 変換したメッセージに対しても再帰的に処理するかどうか。
+     * @param currentRecursiveDepth 現在の再帰処理回数。
      * @param messageResolver メッセージを解決するクラス。nullの場合、指定しないと同じ意味になります。
      * @return 補完したメッセージ。
      */
-    protected String parse(final String message, final Map<String, ?> vars, boolean recursive, final MessageResolver messageResolver) {
+    protected String parse(final String message, final Map<String, ?> vars, final boolean recursive, final int currentRecursiveDepth,
+            final MessageResolver messageResolver) {
         
         // 評価したメッセージを格納するバッファ。
         final StringBuilder sb = new StringBuilder(message.length());
@@ -156,7 +174,7 @@ public class MessageInterpolator {
                     // エスケープを解除する
                     expression = removeEscapeChar(expression, '\\');
                     
-                    String result = evaluate(expression, vars, recursive, messageResolver);
+                    String result = evaluate(expression, vars, recursive, currentRecursiveDepth, messageResolver);
                     sb.append(result);
                     
                 } else {
@@ -187,7 +205,7 @@ public class MessageInterpolator {
     }
     
     private String evaluate(final String expression, final Map<String, ?> values, final boolean recursive,
-            final MessageResolver messageResolver) {
+            final int currentRecursiveDepth, final MessageResolver messageResolver) {
         
         if(expression.startsWith("{")) {
             // 変数の置換の場合
@@ -197,8 +215,8 @@ public class MessageInterpolator {
                 // 該当するキーが存在する場合
                 final Object value = values.get(varName);
                 final String eval = (value == null) ? "" : value.toString();
-                if(!eval.isEmpty() && recursive) {
-                    return parse(eval, values, recursive, messageResolver);
+                if(!eval.isEmpty() && recursivable(recursive && recursiveForVar, maxRecursiveDepth, currentRecursiveDepth, eval)) {
+                    return parse(eval, values, recursive, currentRecursiveDepth + 1, messageResolver);
                 } else {
                     return eval;
                 }
@@ -211,8 +229,8 @@ public class MessageInterpolator {
                     return String.format("{%s}", varName);
                 }
                 
-                if(recursive) {
-                    return parse(eval.get(), values, recursive, messageResolver);
+                if(recursivable(recursive, maxRecursiveDepth, currentRecursiveDepth, eval.get())) {
+                    return parse(eval.get(), values, recursive, currentRecursiveDepth + 1, messageResolver);
                 } else {
                     return eval.get();
                 }
@@ -226,8 +244,8 @@ public class MessageInterpolator {
             // EL式で処理する
             final String expr = expression.substring(2, expression.length()-1);
             final String eval = evaluateExpression(expr, values);
-            if(recursive) {
-                return parse(eval, values, recursive, messageResolver);
+            if(recursive && recursivable(recursive && recursiveForEl, maxRecursiveDepth, currentRecursiveDepth, eval)) {
+                return parse(eval, values, recursive,currentRecursiveDepth + 1, messageResolver);
             } else {
                 return eval;
             }
@@ -236,6 +254,37 @@ public class MessageInterpolator {
         
         throw new MessageParseException(expression, "not support expression.");
         
+    }
+    
+    /**
+     * 現在の再帰回数が最大回数に達しているかどうか。
+     * 
+     * @param recursive 再帰的に処理するかどうか。
+     * @param maxRecursion 最大再帰回数
+     * @param currentDepth 再帰回数
+     * @param expression 再帰対象のメッセージ
+     * @return 最大再帰回数を超えていなければfalseを返す。
+     */
+    private boolean recursivable(final boolean recursive, final int maxRecursion, final int currentDepth,
+            String message) {
+
+        if(!recursive) {
+            return false;
+        }
+
+        if(maxRecursion <= 0) {
+            // 再帰回数の制限なし。
+            return true;
+        }
+
+        if(currentDepth <= maxRecursion) {
+            return true;
+        }
+
+        logger.warn("Over recursive depth : currentDepth={}, maxDepth={}, message={}.", currentDepth, maxRecursion, message);
+
+        return false;
+
     }
     
     /**
@@ -325,5 +374,70 @@ public class MessageInterpolator {
     public void setExpressionLanguage(ExpressionLanguage expressionLanguage) {
         this.expressionLanguage = expressionLanguage;
     }
+
+    /**
+     * EL式を再帰的に評価するかどうか判定する。
+     * 
+     * @since 2.4
+     * @return {@literal true}のとき再帰的に処理しない。
+     */
+    public boolean isRecursiveForEl() {
+        return recursiveForEl;
+    }
     
+    /**
+     * EL式を再帰的に評価するかどうか設定する。
+     * <p>入力値などの任意の値がEL式(<code>${...}</code>)の形式の場合、
+     *    不要に再帰的に評価されてELインジェクションが発生してしまうのを防ぐために設定します。
+     * <p>デフォルト値は、{@literal false} と再帰的に評価しない。
+     * 
+     * @since 2.4
+     * @param recursiveForEl {@literal true}のとき再帰的に処理しない。
+     */
+    public void setRecursiveForEl(boolean recursiveForEl) {
+        this.recursiveForEl = recursiveForEl;
+    }
+    
+    /**
+     * 変数を再帰的に評価するかどうか判定する。
+     * 
+     * @since 2.4
+     * @return {@literal true}のとき再帰的評価する。
+     */
+    public boolean isRecursiveForVar() {
+        return recursiveForVar;
+    }
+    
+    /**
+     * リソースファイルのキーを除く変数を再帰的に処理しないかどうか設定する。
+     * <p>入力値などの任意の値が変数(<code>{...}</code>)の形式の場合、
+     *   不要に再帰的に評価されてELインジェクションが発生してしまうのを防ぐために設定します。
+     * <p>デフォルト値は、{@literal false} と再帰的に評価しない。
+     * 
+     * @since 2.4
+     * @param recursiveForVar {@literal true}のとき再帰的評価する。
+     */
+    public void setRecursiveForVar(boolean recursiveForVar) {
+        this.recursiveForVar = recursiveForVar;
+    }
+    
+    /**
+     * 評価した変数やEL式を再帰的に処するときの最大回数を取得します。
+     * 
+     * @since 2.4
+     * @return 再帰的に処するときの最大回数。
+     */
+    public int getMaxRecursiveDepth() {
+        return maxRecursiveDepth;
+    }
+    
+    /**
+     * 評価した変数やEL式を再帰的に処するときの最大回数を設定します。
+     * 
+     * @since 2.4
+     * @param maxRecursiveDepth 再帰的に処するときの最大回数。{@literal -1} のとき制限はありません。
+     */
+    public void setMaxRecursiveDepth(int maxRecursiveDepth) {
+        this.maxRecursiveDepth = maxRecursiveDepth;
+    }
 }

--- a/src/main/java/com/github/mygreen/supercsv/localization/MessageInterpolator.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/MessageInterpolator.java
@@ -36,16 +36,6 @@ public class MessageInterpolator {
     private ExpressionLanguage expressionLanguage;
     
     /**
-     * EL式を再帰的に評価するかどうか。
-     */
-    private boolean recursiveForEl = false;
-    
-    /**
-     * 変数を再帰的に評価するかどうか。
-     */
-    private boolean recursiveForVar = false;
-    
-    /**
      * 再帰処理の最大回数
      */
     private int maxRecursiveDepth = 5;
@@ -212,14 +202,10 @@ public class MessageInterpolator {
             final String varName = expression.substring(1, expression.length()-1);
             
             if(values.containsKey(varName)) {
-                // 該当するキーが存在する場合
+                // 該当するキーが存在する場合（再帰評価は行わない）
                 final Object value = values.get(varName);
-                final String eval = (value == null) ? "" : value.toString();
-                if(!eval.isEmpty() && recursivable(recursive && recursiveForVar, maxRecursiveDepth, currentRecursiveDepth, eval)) {
-                    return parse(eval, values, recursive, currentRecursiveDepth + 1, messageResolver);
-                } else {
-                    return eval;
-                }
+                final String eval = Objects.toString(value, "");
+                return eval;
                 
             } else if(messageResolver != null) {
                 // メッセージコードをとして解決をする。
@@ -241,14 +227,10 @@ public class MessageInterpolator {
             }
             
         } else if(expression.startsWith("${")) {
-            // EL式で処理する
+            // EL式を評価する（再帰評価は行わない）
             final String expr = expression.substring(2, expression.length()-1);
             final String eval = evaluateExpression(expr, values);
-            if(recursive && recursivable(recursive && recursiveForEl, maxRecursiveDepth, currentRecursiveDepth, eval)) {
-                return parse(eval, values, recursive,currentRecursiveDepth + 1, messageResolver);
-            } else {
-                return eval;
-            }
+            return eval;
             
         }
         
@@ -373,52 +355,6 @@ public class MessageInterpolator {
      */
     public void setExpressionLanguage(ExpressionLanguage expressionLanguage) {
         this.expressionLanguage = expressionLanguage;
-    }
-
-    /**
-     * EL式を再帰的に評価するかどうか判定する。
-     * 
-     * @since 2.4
-     * @return {@literal true}のとき再帰的に処理しない。
-     */
-    public boolean isRecursiveForEl() {
-        return recursiveForEl;
-    }
-    
-    /**
-     * EL式を再帰的に評価するかどうか設定する。
-     * <p>入力値などの任意の値がEL式(<code>${...}</code>)の形式の場合、
-     *    不要に再帰的に評価されてELインジェクションが発生してしまうのを防ぐために設定します。
-     * <p>デフォルト値は、{@literal false} と再帰的に評価しない。
-     * 
-     * @since 2.4
-     * @param recursiveForEl {@literal true}のとき再帰的に処理しない。
-     */
-    public void setRecursiveForEl(boolean recursiveForEl) {
-        this.recursiveForEl = recursiveForEl;
-    }
-    
-    /**
-     * 変数を再帰的に評価するかどうか判定する。
-     * 
-     * @since 2.4
-     * @return {@literal true}のとき再帰的評価する。
-     */
-    public boolean isRecursiveForVar() {
-        return recursiveForVar;
-    }
-    
-    /**
-     * リソースファイルのキーを除く変数を再帰的に処理しないかどうか設定する。
-     * <p>入力値などの任意の値が変数(<code>{...}</code>)の形式の場合、
-     *   不要に再帰的に評価されてELインジェクションが発生してしまうのを防ぐために設定します。
-     * <p>デフォルト値は、{@literal false} と再帰的に評価しない。
-     * 
-     * @since 2.4
-     * @param recursiveForVar {@literal true}のとき再帰的評価する。
-     */
-    public void setRecursiveForVar(boolean recursiveForVar) {
-        this.recursiveForVar = recursiveForVar;
     }
     
     /**

--- a/src/main/java/com/github/mygreen/supercsv/validation/CsvError.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/CsvError.java
@@ -66,7 +66,7 @@ public class CsvError implements Serializable {
             
         }
         
-        // デフォルトメッセージはBeanValidationのとき変数を追加している場合があるため、再度フォーマットする。
+        // ユーザー指定のときはエラーコード指定がなため、デフォルトメッセージでフォーマットする。
         return messageInterpolator.interpolate(getDefaultMessage(), getVariables(), true, messageResolver);
     }
     

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidator.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidator.java
@@ -1,5 +1,6 @@
 package com.github.mygreen.supercsv.validation.beanvalidation;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -13,6 +14,9 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.metadata.ConstraintDescriptor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.localization.MessageInterpolator;
 import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
@@ -24,12 +28,14 @@ import com.github.mygreen.supercsv.validation.ValidationContext;
 /**
  * BeanValidaion JSR-303(ver.1.0)/JSR-349(ver.1.1)にブリッジする{@link CsvValidator}。
  * 
- * @version 2.3
+ * @version 2.4
  * @since 2.0
  * @author T.TSUCHIE
  *
  */
 public class CsvBeanValidator implements CsvValidator<Object> {
+    
+    private static final Logger logger = LoggerFactory.getLogger(CsvBeanValidator.class);
     
     /**
      * BeanValidationのアノテーションの属性で、メッセージ中の変数から除外するもの。
@@ -140,14 +146,12 @@ public class CsvBeanValidator implements CsvValidator<Object> {
                 final Object fieldValue = violation.getInvalidValue();
                 errorVars.computeIfAbsent("validatedValue", key -> fieldValue);
                 
-                String defaultMessage = violation.getMessage();
-                
                 bindingErrors.rejectValue(field, columnMapping.getField().getType(), 
-                        errorCodes, errorVars, defaultMessage);
+                        errorCodes, errorVars, violation.getMessageTemplate());
                 
             } else {
                 // オブジェクトエラーの場合
-                bindingErrors.reject(errorCodes, errorVars, violation.getMessage());
+                bindingErrors.reject(errorCodes, errorVars, violation.getMessageTemplate());
                 
             }
             
@@ -157,17 +161,40 @@ public class CsvBeanValidator implements CsvValidator<Object> {
     }
     
     /**
-     * エラーコードの決定する
+     * エラーコードを決定する。
+     * <p>※ユーザ指定メッセージの場合はエラーコードは空。</p>
+     * 
+     * @since 2.4
      * @param descriptor フィールド情報
      * @return エラーコード
      */
-    protected String[] determineErrorCode(ConstraintDescriptor<?> descriptor) {
-        return new String[] {
-                descriptor.getAnnotation().annotationType().getSimpleName()/*,
-                descriptor.getAnnotation().annotationType().getCanonicalName(),
-                descriptor.getAnnotation().annotationType().getCanonicalName() + ".message"
-                */
-        };
+    protected String[] determineErrorCode(final ConstraintDescriptor<?> descriptor) {
+        
+        // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
+        String defaultMessage = null;
+        try {
+            Method messageMethod = descriptor.getAnnotation().annotationType().getMethod("message");
+            messageMethod.setAccessible(true);
+            defaultMessage = Objects.toString(messageMethod.getDefaultValue(), null);
+        } catch (NoSuchMethodException | SecurityException e) {
+            logger.warn("Fail getting annotation's attribute 'message' for " + descriptor.getAnnotation().annotationType().getSimpleName() , e);
+        }
+        
+        if(!descriptor.getMessageTemplate().equals(defaultMessage)) {
+            /*
+             * アノテーション属性「message」の値がデフォルト値から変更されている場合は、
+             * ユーザー指定メッセージとして判断し、エラーコードは空にしてユーザー指定メッセージを優先させる。
+             */
+            return new String[]{};
+            
+        } else {
+            // アノテーションのクラス名をもとに生成する。
+            return new String[]{
+                    descriptor.getAnnotation().annotationType().getSimpleName(),
+                    descriptor.getAnnotation().annotationType().getCanonicalName(),
+                    descriptor.getAnnotation().annotationType().getCanonicalName() + ".message"
+            };
+        }
     }
     
     /**

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/MessageInterpolatorAdapter.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/MessageInterpolatorAdapter.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.validation.metadata.ConstraintDescriptor;
 
@@ -69,14 +68,6 @@ public class MessageInterpolatorAdapter implements javax.validation.MessageInter
         
         // 検証対象の値
         vars.computeIfAbsent("validatedValue", key -> context.getValidatedValue());
-        
-        // デフォルトのメッセージ
-        final String defaultCode = String.format("%s.message", descriptor.getAnnotation().annotationType().getCanonicalName());
-        final Optional<String> defaultMessage = messageResolver.getMessage(defaultCode);
-        
-        vars.put(defaultCode, 
-                defaultMessage.orElseThrow(() -> new RuntimeException(String.format("not found message code '%s'", defaultCode))));
-        
         
         return vars;
         

--- a/src/test/java/com/github/mygreen/supercsv/cellprocessor/constraint/PatternFactoryTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/cellprocessor/constraint/PatternFactoryTest.java
@@ -1,9 +1,10 @@
 package com.github.mygreen.supercsv.cellprocessor.constraint;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.github.mygreen.supercsv.tool.HasCellProcessorAssert.assertThat;
 import static com.github.mygreen.supercsv.tool.TestUtils.*;
-import static com.github.mygreen.supercsv.tool.HasCellProcessorAssert.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import java.lang.annotation.Annotation;
 import java.util.Comparator;
@@ -20,13 +21,12 @@ import com.github.mygreen.supercsv.annotation.CsvBean;
 import com.github.mygreen.supercsv.annotation.CsvColumn;
 import com.github.mygreen.supercsv.annotation.PatternFlag;
 import com.github.mygreen.supercsv.annotation.constraint.CsvPattern;
-import com.github.mygreen.supercsv.builder.ProcessorBuilderResolver;
 import com.github.mygreen.supercsv.builder.BeanMapping;
 import com.github.mygreen.supercsv.builder.BeanMappingFactory;
-import com.github.mygreen.supercsv.builder.BuildCase;
 import com.github.mygreen.supercsv.builder.ColumnMapping;
 import com.github.mygreen.supercsv.builder.Configuration;
 import com.github.mygreen.supercsv.builder.FieldAccessor;
+import com.github.mygreen.supercsv.builder.ProcessorBuilderResolver;
 import com.github.mygreen.supercsv.builder.standard.StringProcessorBuilder;
 import com.github.mygreen.supercsv.cellprocessor.format.TextFormatter;
 import com.github.mygreen.supercsv.exception.SuperCsvInvalidAnnotationException;
@@ -287,7 +287,7 @@ public class PatternFactoryTest {
             
             List<String> messages = exceptionConverter.convertAndFormat((SuperCsvValidationException)e, beanMapping);
             assertThat(messages).hasSize(1)
-                    .contains("[2行, 2列] : 項目「col_description_empty」の値（abcdef）は、正規表現「d{4}-d{2}-d{2}」に一致しません。");
+                    .contains("[2行, 2列] : 項目「col_description_empty」の値（abcdef）は、正規表現「\\d{4}-\\d{2}-\\d{2}」に一致しません。");
         }
         
     }
@@ -377,7 +377,7 @@ public class PatternFactoryTest {
             
             List<String> messages = exceptionConverter.convertAndFormat((SuperCsvValidationException)e, beanMapping);
             assertThat(messages).hasSize(1)
-                    .contains("lineNumber=1, rowNumber=2, columnNumber=12, label=col_message_variables, validatedValue=abcdef, regex=d{4}-d{2}-d{2}, flags=2, description=説明");
+                    .contains("lineNumber=1, rowNumber=2, columnNumber=12, label=col_message_variables, validatedValue=abcdef, regex=\\d{4}-\\d{2}-\\d{2}, flags=2, description=説明");
         }
         
     }

--- a/src/test/java/com/github/mygreen/supercsv/io/CsvAnnotationBeanReaderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/io/CsvAnnotationBeanReaderTest.java
@@ -357,7 +357,7 @@ public class CsvAnnotationBeanReaderTest {
         List<String> messages = csvReader.getErrorMessages();
         // ELインジェクション対象の式は空文字として変換される。
         assertThat(messages).hasSize(1)
-            .contains("[1行]  : ヘッダーの値「id, abcefg」は、「id, value」と一致しません。");
+            .contains("[1行]  : ヘッダーの値「id, abc${''.getClass().forName('java.lang.Runtime').getRuntime().exec('notepad')}efg」は、「id, value」と一致しません。");
         messages.forEach(System.out::println);
         
     }
@@ -402,7 +402,7 @@ public class CsvAnnotationBeanReaderTest {
         List<String> messages = csvReader.getErrorMessages();
         // ELインジェクション対象の式は空文字として変換される。
         assertThat(messages).hasSize(1)
-            .contains("[2行, 2列] : 項目「value」の値（abcefg）には、禁止語彙 「getRuntime」が含まれています。");
+            .contains("[2行, 2列] : 項目「value」の値（abc${''.getClass().forName('java.lang.Runtime').getRuntime().exec('notepad')}efg）には、禁止語彙 「getRuntime」が含まれています。");
         messages.forEach(System.out::println);
         
     }

--- a/src/test/java/com/github/mygreen/supercsv/localization/MessageInterpolatorTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/localization/MessageInterpolatorTest.java
@@ -1,0 +1,269 @@
+package com.github.mygreen.supercsv.localization;
+
+import static com.github.mygreen.supercsv.tool.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+
+/**
+ * {@link MessageInterpolator}のテスタ。
+ *
+ * @since 2.4
+ * @author T.TSUCHIE
+ *
+ */
+public class MessageInterpolatorTest {
+    
+    /**
+     * 変数のみ - EL式なし
+     */
+    @Test
+    public void testInterpolate_var() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "{validatedValue} は、{min}～{max}の範囲で入力してください。";
+        
+        int validatedValue = 3;
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("validatedValue", validatedValue);
+        vars.put("min", 1);
+        vars.put("max", 10);
+        
+        String actual = interpolator.interpolate(message, vars);
+        assertThat(actual).isEqualTo("3 は、1～10の範囲で入力してください。");
+        
+    }
+    
+    /**
+     * EL式あり - 数値のフォーマット
+     */
+    @Test
+    public void testInterpolate_el01() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "${formatter.format('%1.1f', validatedValue)}は、${min}～${max}の範囲で入力してください。";
+        
+        double validatedValue = 3;
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("validatedValue", validatedValue);
+        vars.put("min", 1);
+        vars.put("max", 10);
+        
+        String actual = interpolator.interpolate(message, vars);
+        assertThat(actual).isEqualTo("3.0は、1～10の範囲で入力してください。");
+        
+    }
+    
+    /**
+     * EL式あり - 日付のフォーマット
+     */
+    @Test
+    public void testInterpolate_el02() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "現在の日付「${formatter.format('%1$tY/%1$tm/%1$td', validatedValue)}」は未来日です。";
+        
+        Date validatedValue = toTimestamp("2015-05-01 12:31:49.000");
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("validatedValue", validatedValue);
+        
+        String actual = interpolator.interpolate(message, vars);
+        assertThat(actual).isEqualTo("現在の日付「2015/05/01」は未来日です。");
+//        System.out.println(actual);
+        
+    }
+    
+    /**
+     * EL式中にエスケープ文字あり
+     */
+    @Test
+    public void testInterpolate_escape01() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "\\${formatter.format('%1.1f',validatedValue)}は、\\{min}～${max}の範囲で入力してください。";
+        
+        double validatedValue = 3;
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("validatedValue", validatedValue);
+        vars.put("min", 1);
+        vars.put("max", 10);
+        
+        String actual = interpolator.interpolate(message, vars);
+        assertThat(actual).isEqualTo("${formatter.format('%1.1f',validatedValue)}は、{min}～10の範囲で入力してください。");
+//        System.out.println(actual);
+        
+    }
+    
+    /**
+     * EL式中にエスケープ文字あり
+     */
+    @Test
+    public void testInterpolate_escape02() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "${'Helo World\\}' + formatter.format('%1.1f', validatedValue)}は、{min}～${max}の範囲で入力してください。";
+        
+        double validatedValue = 3;
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("validatedValue", validatedValue);
+        vars.put("min", 1);
+        vars.put("max", 10);
+        
+        String actual = interpolator.interpolate(message, vars);
+        assertThat(actual).isEqualTo("Helo World}3.0は、1～10の範囲で入力してください。");
+//        System.out.println(actual);
+        
+    }
+    
+    /**
+     * メッセージ中の式が途中で終わる場合
+     */
+    @Test
+    public void testInterpolate_lack_end() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "${'Helo World\\}' += formatter.format('%1.1f', validatedValue)";
+        
+        double validatedValue = 3;
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("validatedValue", validatedValue);
+        vars.put("min", 1);
+        vars.put("max", 10);
+        
+        String actual = interpolator.interpolate(message, vars);
+        
+        assertThat(actual).isEqualTo("${'Helo World}' += formatter.format('%1.1f', validatedValue)");
+    }
+    
+    /**
+     * 再起的にメッセージを評価する。
+     * 変数の再起
+     */
+    @Test
+    public void testInterpolate_recursive_vars() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        interpolator.setRecursiveForVar(true);
+        
+        String message = "{abc} : {message}";
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("message", "${1+2}");
+        
+        String actual = interpolator.interpolate(message, vars, true);
+        assertThat(actual).isEqualTo("{abc} : 3");
+        
+    }
+    
+    /**
+     * 再起的にメッセージを評価する。
+     * 式の再起
+     */
+    @Test
+    public void testInterpolate_recursive_el() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        interpolator.setRecursiveForEl(true);
+        
+        String message = "{abc} : ${value}";
+        
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("value", "{min}");
+        vars.put("min", 3);
+        
+        String actual = interpolator.interpolate(message, vars, true);
+        assertThat(actual).isEqualTo("{abc} : 3");
+        
+    }
+    
+    /**
+     * 式中の変数の値がない場合
+     */
+    @Test
+    public void testInterpolate_no_define_vars() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "{rowNumber}";
+        
+        Map<String, Object> vars = new HashMap<>();
+        
+        String actual = interpolator.interpolate(message, vars, true);
+        assertThat(actual).isEqualTo("{rowNumber}");
+        
+    }
+    
+    /**
+     * 再起的にメッセージを評価する。
+     * 再帰回数
+     */
+    @Test
+    public void testInterpolate_recursive_maxDepth() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        interpolator.setRecursiveForVar(true);
+        
+        String message = "{abc} : {value}";
+        
+        // depth2
+        {
+            interpolator.setMaxRecursiveDepth(2);
+            
+            Map<String, Object> vars = new HashMap<>();
+            vars.put("value", "{min}");
+            vars.put("min", "{value}");
+            
+            String actual = interpolator.interpolate(message, vars, true);
+            assertThat(actual).isEqualTo("{abc} : {value}");
+        
+        }
+        
+        // depth3
+        {
+            interpolator.setMaxRecursiveDepth(3);
+            
+            Map<String, Object> vars = new HashMap<>();
+            vars.put("value", "{min}");
+            vars.put("min", "{value}");
+            
+            String actual = interpolator.interpolate(message, vars, true);
+            assertThat(actual).isEqualTo("{abc} : {min}");
+        
+        }
+        
+    }
+    
+    /**
+     * 式中の変数の値がない場合
+     */
+    @Test
+    public void testInterpolate_no_define_vars2() {
+        
+        MessageInterpolator interpolator = new MessageInterpolator();
+        
+        String message = "${rowNumber}";
+        
+        Map<String, Object> vars = new HashMap<>();
+        
+        String actual = interpolator.interpolate(message, vars, true);
+        assertThat(actual).isEqualTo("");
+        
+    }
+}

--- a/src/test/java/com/github/mygreen/supercsv/localization/MessageInterpolatorTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/localization/MessageInterpolatorTest.java
@@ -3,9 +3,11 @@ package com.github.mygreen.supercsv.localization;
 import static com.github.mygreen.supercsv.tool.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import org.junit.Test;
 
@@ -18,6 +20,8 @@ import org.junit.Test;
  *
  */
 public class MessageInterpolatorTest {
+    
+    private MessageResolver testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
     
     /**
      * 変数のみ - EL式なし
@@ -153,47 +157,6 @@ public class MessageInterpolatorTest {
     }
     
     /**
-     * 再起的にメッセージを評価する。
-     * 変数の再起
-     */
-    @Test
-    public void testInterpolate_recursive_vars() {
-        
-        MessageInterpolator interpolator = new MessageInterpolator();
-        interpolator.setRecursiveForVar(true);
-        
-        String message = "{abc} : {message}";
-        
-        Map<String, Object> vars = new HashMap<>();
-        vars.put("message", "${1+2}");
-        
-        String actual = interpolator.interpolate(message, vars, true);
-        assertThat(actual).isEqualTo("{abc} : 3");
-        
-    }
-    
-    /**
-     * 再起的にメッセージを評価する。
-     * 式の再起
-     */
-    @Test
-    public void testInterpolate_recursive_el() {
-        
-        MessageInterpolator interpolator = new MessageInterpolator();
-        interpolator.setRecursiveForEl(true);
-        
-        String message = "{abc} : ${value}";
-        
-        Map<String, Object> vars = new HashMap<>();
-        vars.put("value", "{min}");
-        vars.put("min", 3);
-        
-        String actual = interpolator.interpolate(message, vars, true);
-        assertThat(actual).isEqualTo("{abc} : 3");
-        
-    }
-    
-    /**
      * 式中の変数の値がない場合
      */
     @Test
@@ -218,20 +181,17 @@ public class MessageInterpolatorTest {
     public void testInterpolate_recursive_maxDepth() {
         
         MessageInterpolator interpolator = new MessageInterpolator();
-        interpolator.setRecursiveForVar(true);
         
-        String message = "{abc} : {value}";
+        String message = "{abc} : {testRecursive.value}";
         
         // depth2
         {
             interpolator.setMaxRecursiveDepth(2);
             
-            Map<String, Object> vars = new HashMap<>();
-            vars.put("value", "{min}");
-            vars.put("min", "{value}");
+            Map<String, Object> vars = Collections.emptyMap();
             
-            String actual = interpolator.interpolate(message, vars, true);
-            assertThat(actual).isEqualTo("{abc} : {value}");
+            String actual = interpolator.interpolate(message, vars, true, testMessageResolver);
+            assertThat(actual).isEqualTo("{abc} : {testRecursive.value}");
         
         }
         
@@ -239,12 +199,10 @@ public class MessageInterpolatorTest {
         {
             interpolator.setMaxRecursiveDepth(3);
             
-            Map<String, Object> vars = new HashMap<>();
-            vars.put("value", "{min}");
-            vars.put("min", "{value}");
+            Map<String, Object> vars = Collections.emptyMap();
             
-            String actual = interpolator.interpolate(message, vars, true);
-            assertThat(actual).isEqualTo("{abc} : {min}");
+            String actual = interpolator.interpolate(message, vars, true, testMessageResolver);
+            assertThat(actual).isEqualTo("{abc} : {testRecursive.min}");
         
         }
         

--- a/src/test/java/com/github/mygreen/supercsv/tool/TestUtils.java
+++ b/src/test/java/com/github/mygreen/supercsv/tool/TestUtils.java
@@ -191,6 +191,10 @@ public class TestUtils {
         return new Timestamp(date.getTime());
     }
     
+    public static Timestamp toTimestamp(final String value) {
+        return Timestamp.valueOf(value);
+    }
+    
     public static Time toTime(final int hour, final int minute, final int second) {
         
         Calendar cal = Calendar.getInstance();

--- a/src/test/resources/TestMessages.properties
+++ b/src/test/resources/TestMessages.properties
@@ -15,6 +15,9 @@ defaultRead.value.int=1,234
 defaultWrite.value.string=あいう
 defaultWrite.value.int=1,234
 
+# 再帰用のテスト
+testRecursive.value={testRecursive.min}
+testRecursive.min={testRecursive.value}
 
 
 # パースエラー時のメッセージ

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
 			<level>TRACE</level>
 		</filter>
 	</appender>
-	<logger name="com.github.mygreen.supercsv" level="DEBUG">
+	<logger name="com.github.mygreen.supercsv" level="DEBUG" additivity="false">
 		<appender-ref ref="CONSOLE" />
 	</logger>
 	<root>


### PR DESCRIPTION
MessageInterpolator でエラーメッセージを組み立てるときに、ELインジェクションの起点とならないように、再帰的評価対象外の設定を追加。

- EL式形式( `${...}`) の場合は、再帰評価しないよう修正。
  - EL式はユーザからの入力値となり任意の値が設定されるが、再帰的に評価する必要はないため。
- 変数形式(`{...}`) の場合、再帰評価しないよう修正。
  - `{validatedValue}` は、ユーザからの入力値となり任意の値が設定されるが、再帰的に評価する必要はないため。
- メッセージソースの再帰評価の回数の上限値として、最大5回までを設定。
  - メッセージソースの場合、設定によっては無限に再帰評価されてしまいStackOverflowErrorが発生するのを防ぐ。
- `CsvBeanValidation` による BeanValidation のエラーメッセージの処理方を変更。
  - アノテーションの属性 `message` でデフォルトのエラーメッセージ指定して、デフォルト値から変更されていた場合、評価前のテンプレートの状態で渡すように変更し、CsvContextの情報を評価可能にすにする。