### PR TITLE
文字コード指定のプロパティファイルを読み込んだ時文字化けする事象の修正

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,15 +20,21 @@ jobs:
     - name: Set up Locale
       run: |
         sudo apt-get -y install fonts-ipafont language-pack-ja
+        sudo locale-gen ja_JP.UTF-8
         sudo update-locale LANG=ja_JP.UTF-8
         sudo update-locale LC_ALL=ja_JP.UTF-8
+        sudo localectl status
     - name: Set up Time-Zone
       run: sudo timedatectl set-timezone Asia/Tokyo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: 'corretto'
+        java-version: 8
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
     - name: Build with Maven
-      #run: mvn -B package --file pom.xml
       run: mvn -B clean verify -Dgpg.skip=true

--- a/src/main/java/com/github/mygreen/supercsv/localization/EncodingControl.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/EncodingControl.java
@@ -3,8 +3,6 @@ package com.github.mygreen.supercsv.localization;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -13,14 +11,22 @@ import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * {@link ResourceBundle}を任意の文字コードで読み込むためのコントローラ。
+ * プロパティファイル形式のみサポートします。
  *
  * @since 2.2
  * @author T.TSUCHIE
  *
  */
 public class EncodingControl extends ResourceBundle.Control {
+    
+    private static final Logger logger = LoggerFactory.getLogger(EncodingControl.class);
+    
+    private static final String SUPPORT_FORMAT = "java.properties";
     
     private final Charset encoding;
     
@@ -40,97 +46,40 @@ public class EncodingControl extends ResourceBundle.Control {
     }
     
     @Override
-    public ResourceBundle newBundle(final String baseName, final Locale locale, String format, final ClassLoader loader, final boolean reload) 
+    public ResourceBundle newBundle(final String baseName, final Locale locale, final String format,
+            final ClassLoader loader, final boolean reload)
             throws IllegalAccessException, InstantiationException, IOException {
-        
-        String bundleName = toBundleName(baseName, locale);
-        ResourceBundle bundle = null;
-        if (format.equals("java.class"))
-        {
-          try
-          {
-            @SuppressWarnings(
-            { "unchecked" })
-            Class<? extends ResourceBundle> bundleClass = (Class<? extends ResourceBundle>) loader.loadClass(bundleName);
 
-            // If the class isn't a ResourceBundle subclass, throw a
-            // ClassCastException.
-            if (ResourceBundle.class.isAssignableFrom(bundleClass))
-            {
-              bundle = bundleClass.newInstance();
-            }
-            else
-            {
-              throw new ClassCastException(bundleClass.getName() + " cannot be cast to ResourceBundle");
-            }
-          }
-          catch (ClassNotFoundException ignored)
-          {
-          }
-        }
-        else if (format.equals("java.properties"))
-        {
-          final String resourceName = toResourceName(bundleName, "properties");
-          final ClassLoader classLoader = loader;
-          final boolean reloadFlag = reload;
-          InputStreamReader isr = null;
-          InputStream stream;
-          try
-          {
-            stream = AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>()
-            {
-              @Override
-              public InputStream run() throws IOException
-              {
-                InputStream is = null;
-                if (reloadFlag)
-                {
-                  URL url = classLoader.getResource(resourceName);
-                  if (url != null)
-                  {
-                    URLConnection connection = url.openConnection();
-                    if (connection != null)
-                    {
-                      // Disable caches to get fresh data for
-                      // reloading.
-                      connection.setUseCaches(false);
-                      is = connection.getInputStream();
-                    }
-                  }
+        if(format.equals(SUPPORT_FORMAT)) {
+            final String bundleName = toBundleName(baseName, locale);
+            final String resourceName = toResourceName(bundleName, "properties");
+            
+            try (InputStream stream = getResourceStream(loader, resourceName)) {
+                try (InputStreamReader isr = new InputStreamReader(stream, encoding)) {
+                    return new PropertyResourceBundle(isr);
                 }
-                else
-                {
-                  is = classLoader.getResourceAsStream(resourceName);
-                }
-                return is;
-              }
-            });
-            if (stream != null)
-            {
-              isr = new InputStreamReader(stream, encoding);
+            } catch (PrivilegedActionException e) {
+                throw(IOException) e.getException();
             }
-          }
-          catch (PrivilegedActionException e)
-          {
-            throw (IOException) e.getException();
-          }
-          if (isr != null)
-          {
-            try
-            {
-              bundle = new PropertyResourceBundle(isr);
-            }
-            finally
-            {
-              isr.close();
-            }
-          }
+        } else {
+            // 「java.class」はサポートしない。
+            // プロパティファイル(java.properties)のみサポートする。
+            logger.trace("Not support format. baseName={}, format={}, reload={}.", baseName, format, reload);
+            return null;
         }
-        else
-        {
-          throw new IllegalArgumentException("unknown format: " + format);
-        }
-        return bundle;
+
+    }
+    
+    private InputStream getResourceStream(final ClassLoader loader, final String resourceName) throws PrivilegedActionException {
+       
+        return AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>() {
+            
+            @Override
+            public InputStream run() throws IOException {
+                // realod=trueのときもキャッシュを使用せずに新しく読み込む。
+                return loader.getResourceAsStream(resourceName);
+            }
+        });
     }
     
     


### PR DESCRIPTION
## 事象

`EncodingControl` を使用しUTF-8のプロパティファイルをResourceBundle経由で読み込んだ時文字化けする事象を修正。
 Java Distributionや環境によって、`EncodingControl.newBundle(...)` の引数「reload=true」が指定されたとき、URLConnection経由で読み込むため文字化けしてしまう。

## 修正内容
- `EncodingControl` において、realodは無視して、常に `ClassLoader.getResourceAsStream(...)` 経由でInputStreamを取得するよう修正。
  - プロパティファイルの読み込みにしか使用しないため、classファイルの読み込み処理を削除。
- ビルド環境を変更。
  - JDKをCorretoに変更。
  - Mavenのバージョンを3.9.6に固定。
