### PR TITLE
JEXLのstrictパーミッションをoffにするフラグを追加

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/util/Utils.java
+++ b/src/main/java/com/github/mygreen/supercsv/util/Utils.java
@@ -360,4 +360,35 @@ public class Utils {
             .toString();
     }
     
+    /**
+     * 文字列をトリムする。
+     * @param value トリム対象の文字
+     * @param trimmed トリムするかどうか。
+     * @return トリミングした結果。
+     */
+    public static String trim(final String value, final boolean trimmed) {
+        if(!trimmed || value == null) {
+            return value;
+        }
+
+        return value.trim();
+
+    }
+    
+    /**
+     * 文字列をbooleanに変換します。
+     * 
+     * @param value 変換対象の値。
+     * @param defaultValue 変換対象がnull or 空文字の時のデフォルト値。
+     * @return 引数がnullのとき、falseを返します。
+     */
+    public static boolean toBoolean(final String value, final boolean defaultValue) {
+        String text = trim(value, true);
+        if(isEmpty(text)) {
+            return defaultValue;
+        }
+        
+        return Boolean.valueOf(text.toLowerCase());
+    }
+    
 }


### PR DESCRIPTION
JEXLのStrictパーミッションを制御するシステムプロパティ `supercsv.annotation.jexlRestricted` を追加。

- `supercsv.annotation.jexlRestricted` の値を `false` に指定すると、[JexlPermissions.UNRESTRICTED](https://commons.apache.org/proper/commons-jexl/apidocs/org/apache/commons/jexl3/introspection/JexlPermissions.html#UNRESTRICTED) を使用するよう切り替える。
- - `supercsv.annotation.jexlRestricted` の値を指定しない場合は、デフォルト値true として [JexlPermissions.RESTRICTED](https://commons.apache.org/proper/commons-jexl/apidocs/org/apache/commons/jexl3/introspection/JexlPermissions.html#RESTRICTED) が設定される。