### PR TITLE
Jakarta Bean Validation 3.0対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,28 @@ $(document).ready(function() {
 			<artifactId>commons-jexl3</artifactId>
 			<version>3.4.0</version>
 		</dependency>
+		
+		<!-- Jakarta Bean Validation (Java11以上が必要) -->
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<!--
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>8.0.2.Final</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.expressly</groupId>
+			<artifactId>expressly</artifactId>
+			<version>5.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+		-->
 
 		<!-- Bean Validation 2.0 -->
 		<dependency>
@@ -478,6 +500,14 @@ $(document).ready(function() {
 			<artifactId>logback-classic</artifactId>
 			<version>1.2.11</version>
 			<scope>test</scope>
+		</dependency>
+		
+		<!-- JAXB(Java9以降の場合は必要) -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+			<scope>provided</scope>
 		</dependency>
 		
 	</dependencies>

--- a/src/main/java/com/github/mygreen/supercsv/localization/SuperCsvMessages.properties
+++ b/src/main/java/com/github/mygreen/supercsv/localization/SuperCsvMessages.properties
@@ -99,12 +99,37 @@ javax.validation.constraints.Positive.message={csvContext} : 項目「{label}」
 javax.validation.constraints.PositiveOrZero.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、0以上の値を設定してください。
 javax.validation.constraints.Email.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、E-mail形式で設定してください。
 
+## Jakarta Bean Validation 3.0のメッセージ
+jakarta.validation.constraints.AssertFalse.message={javax.validation.constraints.AssertFalse.message}
+jakarta.validation.constraints.AssertTrue.message={javax.validation.constraints.AssertTrue.message}
+jakarta.validation.constraints.DecimalMax.message={javax.validation.constraints.DecimalMax.message}
+jakarta.validation.constraints.DecimalMin.message={javax.validation.constraints.DecimalMin.message}
+jakarta.validation.constraints.Digits.message={javax.validation.constraints.Digits.message}
+jakarta.validation.constraints.Email.message={javax.validation.constraints.Email.message}
+jakarta.validation.constraints.Future.message={javax.validation.constraints.Future.message}
+jakarta.validation.constraints.FutureOrPresent.message={javax.validation.constraints.FutureOrPresent.message}
+jakarta.validation.constraints.Max.message={javax.validation.constraints.Max.message}
+jakarta.validation.constraints.Min.message={javax.validation.constraints.Min.message}
+jakarta.validation.constraints.Negative.message={javax.validation.constraints.Negative.message}
+jakarta.validation.constraints.NegativeOrZero.message={javax.validation.constraints.NegativeOrZero.message}
+jakarta.validation.constraints.NotBlank.message={javax.validation.constraints.NotBlank.message}
+jakarta.validation.constraints.NotEmpty.message={javax.validation.constraints.NotEmpty.message}
+jakarta.validation.constraints.NotNull.message={javax.validation.constraints.NotNull.message}
+jakarta.validation.constraints.Null.message={javax.validation.constraints.Null.message}
+jakarta.validation.constraints.Past.message={javax.validation.constraints.Past.message}
+jakarta.validation.constraints.PastOrPresent.message={javax.validation.constraints.PastOrPresent.message}
+jakarta.validation.constraints.Pattern.message={javax.validation.constraints.Pattern.message}
+jakarta.validation.constraints.Positive.message={javax.validation.constraints.Positive.message}
+jakarta.validation.constraints.PositiveOrZero.message={javax.validation.constraints.PositiveOrZero.message}
+jakarta.validation.constraints.Size.message={javax.validation.constraints.Size.message}
 
 ## Hibernate Validatorのエラーメッセージ
 org.hibernate.validator.constraints.CreditCardNumber.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、不正なクレジットカードの番号です。
 org.hibernate.validator.constraints.EAN.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、不正な{type}のコードです。
+org.hibernate.validator.constraints.ISBN.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、不正な ISBN です。
 org.hibernate.validator.constraints.Email.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、E-mail形式で設定してください。
 org.hibernate.validator.constraints.Length.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、文字の長さは{min}から{max}の間で設定してください。
+org.hibernate.validator.constraints.CodePointLength.message={csvContext} : 項目「{label}」の文字長'${validatedValue.length()}'は、{min}～{max}の間で設定してください。
 org.hibernate.validator.constraints.LuhnCheck.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、Luhn Module 10 チェックサムの値が不正です。
 org.hibernate.validator.constraints.Mod10Check.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、Module 10 チェックサムの値が不正です。
 org.hibernate.validator.constraints.Mod11Check.message={csvContext} : 項目「{label}」の値（${empty(printer) ? validatedValue : printer.print(validatedValue)}）は、Luhn Module 11 チェックサムの値が不正です。

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidator.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidator.java
@@ -64,7 +64,7 @@ public class CsvBeanValidator implements CsvValidator<Object> {
     
     /**
      * Bean Validatonのデフォルトのインスタンスを取得する。
-     * @return 
+     * @return Validatorを取得します。
      */
     private Validator createDefaultValidator() {
         final ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
@@ -79,7 +79,7 @@ public class CsvBeanValidator implements CsvValidator<Object> {
     
     /**
      * BeanValidationのValidatorを取得する。
-     * @return
+     * @return Validatorを取得します。
      */
     public Validator getTargetValidator() {
         return targetValidator;

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidator.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/CsvBeanValidator.java
@@ -67,10 +67,11 @@ public class CsvBeanValidator implements CsvValidator<Object> {
      * @return 
      */
     private Validator createDefaultValidator() {
-        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        final ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
+                .messageInterpolator(new MessageInterpolatorAdapter(new ResourceBundleMessageResolver(), new MessageInterpolator()))
+                .buildValidatorFactory();
         
         final Validator validator = validatorFactory.usingContext()
-                .messageInterpolator(new MessageInterpolatorAdapter(new ResourceBundleMessageResolver(), new MessageInterpolator()))
                 .getValidator();
         
         return validator;

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaCsvBeanValidator.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaCsvBeanValidator.java
@@ -1,0 +1,235 @@
+package com.github.mygreen.supercsv.validation.beanvalidation;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.mygreen.supercsv.builder.ColumnMapping;
+import com.github.mygreen.supercsv.localization.MessageInterpolator;
+import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
+import com.github.mygreen.supercsv.validation.CsvBindingErrors;
+import com.github.mygreen.supercsv.validation.CsvFieldError;
+import com.github.mygreen.supercsv.validation.CsvValidator;
+import com.github.mygreen.supercsv.validation.ValidationContext;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.metadata.ConstraintDescriptor;
+
+/**
+ * Jakarata Bean Validaion 3.0/3.1 を利用したValidatorにブリッジする{@link CsvValidator}。
+ * 
+ * @since 2.4
+ * @author T.TSUCHIE
+ *
+ */
+public class JakartaCsvBeanValidator implements CsvValidator<Object> {
+    
+    private static final Logger logger = LoggerFactory.getLogger(JakartaCsvBeanValidator.class);
+    
+    /**
+     * BeanValidationのアノテーションの属性で、メッセージ中の変数から除外するもの。
+     * <p>メッセージの再構築を行う際に必要
+     */
+    private static final Set<String> EXCLUDE_MESSAGE_ANNOTATION_ATTRIBUTES;
+    static {
+        Set<String> set = new HashSet<String>(3);
+        set.add("message");
+        set.add("groups");
+        set.add("payload");
+        
+        EXCLUDE_MESSAGE_ANNOTATION_ATTRIBUTES = Collections.unmodifiableSet(set);
+    }
+    
+    private final Validator targetValidator;
+    
+    public JakartaCsvBeanValidator(final Validator targetValidator) {
+        Objects.requireNonNull(targetValidator);
+        this.targetValidator = targetValidator;
+    }
+    
+    public JakartaCsvBeanValidator() {
+        this.targetValidator = createDefaultValidator();
+    }
+    
+    /**
+     * Bean Validatonのデフォルトのインスタンスを取得する。
+     * @return 
+     */
+    private Validator createDefaultValidator() {
+        final ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
+                .messageInterpolator(new JakartaMessageInterpolatorAdapter(new ResourceBundleMessageResolver(), new MessageInterpolator()))
+                .buildValidatorFactory();
+        
+        final Validator validator = validatorFactory.usingContext()
+                .getValidator();
+        
+        return validator;
+    }
+    
+    /**
+     * BeanValidationのValidatorを取得する。
+     * @return
+     */
+    public Validator getTargetValidator() {
+        return targetValidator;
+    }
+    
+    @Override
+    public void validate(final Object record, final CsvBindingErrors bindingErrors, 
+            final ValidationContext<Object> validationContext) {
+        validate(record, bindingErrors, validationContext, validationContext.getBeanMapping().getGroups());
+        
+    }
+    
+    /**
+     * グループを指定して検証を実行する。
+     * @param record 検証対象のオブジェクト。
+     * @param bindingErrors エラーオブジェクト
+     * @param validationContext 入力値検証のためのコンテキスト情報
+     * @param groups BeanValiationのグループのクラス
+     */
+    public void validate(final Object record, final CsvBindingErrors bindingErrors, 
+            final ValidationContext<Object> validationContext, final Class<?>... groups) {
+        Objects.requireNonNull(record);
+        Objects.requireNonNull(bindingErrors);
+        Objects.requireNonNull(validationContext);
+        
+        processConstraintViolation(getTargetValidator().validate(record, groups), bindingErrors, validationContext);
+    }
+    
+    /**
+     * BeanValidationの検証結果をSheet用のエラーに変換する
+     * @param violations BeanValidationの検証結果
+     * @param bindingErrors エラー情報
+     * @param validationContext 入力値検証のためのコンテキスト情報
+     */
+    private void processConstraintViolation(final Set<ConstraintViolation<Object>> violations,
+            final CsvBindingErrors bindingErrors, final ValidationContext<Object> validationContext) {
+        
+        for(ConstraintViolation<Object> violation : violations) {
+            
+            final String field = violation.getPropertyPath().toString();
+            final ConstraintDescriptor<?> cd = violation.getConstraintDescriptor();
+            
+            final String[] errorCodes = determineErrorCode(cd);
+            
+            final Map<String, Object> errorVars = createVariableForConstraint(cd);
+            
+            if(isCsvField(field, validationContext)) {
+                // フィールドエラーの場合
+                
+                final CsvFieldError fieldError = bindingErrors.getFirstFieldError(field);
+                if(fieldError != null && fieldError.isProcessingFailure()) {
+                    // CellProcessorで発生したエラーが既ににある場合は、処理をスキップする。
+                    continue;
+                }
+                
+                final ColumnMapping columnMapping = validationContext.getBeanMapping().getColumnMapping(field).get();
+                
+                errorVars.put("lineNumber", validationContext.getCsvContext().getLineNumber());
+                errorVars.put("rowNumber", validationContext.getCsvContext().getRowNumber());
+                errorVars.put("columnNumber", columnMapping.getNumber());
+                errorVars.put("label", columnMapping.getLabel());
+                errorVars.computeIfAbsent("printer", key -> columnMapping.getFormatter());
+                
+                // 実際の値を取得する
+                final Object fieldValue = violation.getInvalidValue();
+                errorVars.computeIfAbsent("validatedValue", key -> fieldValue);
+                
+                bindingErrors.rejectValue(field, columnMapping.getField().getType(), 
+                        errorCodes, errorVars, violation.getMessageTemplate());
+                
+            } else {
+                // オブジェクトエラーの場合
+                bindingErrors.reject(errorCodes, errorVars, violation.getMessageTemplate());
+                
+            }
+            
+        }
+        
+        
+    }
+    
+    /**
+     * エラーコードを決定する。
+     * <p>※ユーザ指定メッセージの場合はエラーコードは空。</p>
+     * 
+     * @since 2.4
+     * @param descriptor フィールド情報
+     * @return エラーコード
+     */
+    protected String[] determineErrorCode(final ConstraintDescriptor<?> descriptor) {
+        
+        // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
+        String defaultMessage = null;
+        try {
+            Method messageMethod = descriptor.getAnnotation().annotationType().getMethod("message");
+            messageMethod.setAccessible(true);
+            defaultMessage = Objects.toString(messageMethod.getDefaultValue(), null);
+        } catch (NoSuchMethodException | SecurityException e) {
+            logger.warn("Fail getting annotation's attribute 'message' for " + descriptor.getAnnotation().annotationType().getSimpleName() , e);
+        }
+        
+        if(!descriptor.getMessageTemplate().equals(defaultMessage)) {
+            /*
+             * アノテーション属性「message」の値がデフォルト値から変更されている場合は、
+             * ユーザー指定メッセージとして判断し、エラーコードは空にしてユーザー指定メッセージを優先させる。
+             */
+            return new String[]{};
+            
+        } else {
+            // アノテーションのクラス名をもとに生成する。
+            return new String[]{
+                    descriptor.getAnnotation().annotationType().getSimpleName(),
+                    descriptor.getAnnotation().annotationType().getCanonicalName(),
+                    descriptor.getAnnotation().annotationType().getCanonicalName() + ".message"
+            };
+        }
+    }
+    
+    /**
+     * CSVのカラムのフィールドか判定する。
+     * @param field フィールド名
+     * @param validationContext CSVの検証情報
+     * @return trueのとき、CSVのカラムフィールド。
+     */
+    private boolean isCsvField(final String field, final ValidationContext<Object> validationContext) {
+        return validationContext.getBeanMapping().getColumnMapping(field).isPresent();
+    }
+    
+    /**
+     * BeanValidationのアノテーションの値を元に、メッセージ変数を作成する。
+     * @param descriptor
+     * @return メッセージ変数
+     */
+    private Map<String, Object> createVariableForConstraint(final ConstraintDescriptor<?> descriptor) {
+        
+        final Map<String, Object> vars = new HashMap<>();
+        
+        for(Map.Entry<String, Object> entry : descriptor.getAttributes().entrySet()) {
+            final String attrName = entry.getKey();
+            final Object attrValue = entry.getValue();
+            
+            // メッセージ変数で必要ないものを除外する
+            if(EXCLUDE_MESSAGE_ANNOTATION_ATTRIBUTES.contains(attrName)) {
+                continue;
+            }
+            
+            vars.put(attrName, attrValue);
+        }
+        
+        return vars;
+        
+    }
+    
+}

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaCsvBeanValidator.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaCsvBeanValidator.java
@@ -63,7 +63,7 @@ public class JakartaCsvBeanValidator implements CsvValidator<Object> {
     
     /**
      * Bean Validatonのデフォルトのインスタンスを取得する。
-     * @return 
+     * @return Validatorを取得します。
      */
     private Validator createDefaultValidator() {
         final ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
@@ -78,7 +78,7 @@ public class JakartaCsvBeanValidator implements CsvValidator<Object> {
     
     /**
      * BeanValidationのValidatorを取得する。
-     * @return
+     * @return Validatorを取得します。
      */
     public Validator getTargetValidator() {
         return targetValidator;

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
@@ -1,0 +1,83 @@
+package com.github.mygreen.supercsv.validation.beanvalidation;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import com.github.mygreen.supercsv.localization.MessageInterpolator;
+import com.github.mygreen.supercsv.localization.MessageResolver;
+
+import jakarta.validation.metadata.ConstraintDescriptor;
+
+/**
+ * SuperCsvAnnotationの{@link MessageInterpolator}とBeanValidationの{@link jakarata.validation.MessageInterpolator}をブリッジする。
+ * <p>BeanValidationのメッセージ処理をカスタマイズするために利用する。</p>
+ *
+ * @since 2.4
+ * @author T.TSUCHIE
+ *
+ */
+public class JakartaMessageInterpolatorAdapter implements jakarta.validation.MessageInterpolator {
+    
+    private final MessageResolver messageResolver;
+    
+    private final MessageInterpolator csvMessageInterpolator;
+    
+    /**
+     * 
+     * @param messageResolver
+     * @param csvMessageInterpolator
+     * @throws NullPointerException {@literal if messageResolver or csvMessageInterpolator is null.}
+     */
+    public JakartaMessageInterpolatorAdapter(final MessageResolver messageResolver, final MessageInterpolator csvMessageInterpolator) {
+        Objects.requireNonNull(messageResolver);
+        Objects.requireNonNull(csvMessageInterpolator);
+        
+        this.messageResolver = messageResolver;
+        this.csvMessageInterpolator = csvMessageInterpolator;
+    }
+    
+    @Override
+    public String interpolate(final String messageTemplate, final Context context) {
+        return csvMessageInterpolator.interpolate(messageTemplate, createMessageVariables(context), true, messageResolver);
+    }
+    
+    @Override
+    public String interpolate(final String messageTemplate, final Context context, final Locale locale) {
+        return csvMessageInterpolator.interpolate(messageTemplate, createMessageVariables(context), true, messageResolver);
+    }
+    
+    /**
+     * メッセージ中で利用可能な変数を作成する
+     * @param context コンテキスト
+     * @return メッセージ変数のマップ
+     */
+    private Map<String, Object> createMessageVariables(final Context context) {
+        
+        final Map<String, Object> vars = new HashMap<>();
+        
+        final ConstraintDescriptor<?> descriptor = context.getConstraintDescriptor();
+        for(Map.Entry<String, Object> entry : descriptor.getAttributes().entrySet()) {
+            final String attrName = entry.getKey();
+            final Object attrValue = entry.getValue();
+            
+            vars.put(attrName, attrValue);
+        }
+        
+        // 検証対象の値
+        vars.computeIfAbsent("validatedValue", key -> context.getValidatedValue());
+        
+        return vars;
+        
+    }
+    
+    public MessageResolver getMessageResolver() {
+        return messageResolver;
+    }
+    
+    public MessageInterpolator getCsvMessageInterpolator() {
+        return csvMessageInterpolator;
+    }
+    
+}

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
@@ -11,7 +11,7 @@ import com.github.mygreen.supercsv.localization.MessageResolver;
 import jakarta.validation.metadata.ConstraintDescriptor;
 
 /**
- * SuperCsvAnnotationの{@link MessageInterpolator}とBeanValidationの{@link jakarata.validation.MessageInterpolator}をブリッジする。
+ * SuperCsvAnnotationの{@link MessageInterpolator}とBeanValidationの{@link jakarta.validation.MessageInterpolator}をブリッジする。
  * <p>BeanValidationのメッセージ処理をカスタマイズするために利用する。</p>
  *
  * @since 2.4
@@ -25,9 +25,10 @@ public class JakartaMessageInterpolatorAdapter implements jakarta.validation.Mes
     private final MessageInterpolator csvMessageInterpolator;
     
     /**
+     * SuperCsvAnnotation用のメッセージソースとInterpolatorを指定してBeanValidationのMessageInterpolatorを作成します。
      * 
-     * @param messageResolver
-     * @param csvMessageInterpolator
+     * @param messageResolver SuperCsvAnnotation用のメッセージソース。
+     * @param csvMessageInterpolator SuperCsvAnnotation用のMessageInterpolator。
      * @throws NullPointerException {@literal if messageResolver or csvMessageInterpolator is null.}
      */
     public JakartaMessageInterpolatorAdapter(final MessageResolver messageResolver, final MessageInterpolator csvMessageInterpolator) {

--- a/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/MessageInterpolatorAdapter.java
+++ b/src/main/java/com/github/mygreen/supercsv/validation/beanvalidation/MessageInterpolatorAdapter.java
@@ -26,9 +26,10 @@ public class MessageInterpolatorAdapter implements javax.validation.MessageInter
     private final MessageInterpolator csvMessageInterpolator;
     
     /**
+     * SuperCsvAnnotation用のメッセージソースとInterpolatorを指定してBeanValidationのMessageInterpolatorを作成します。
      * 
-     * @param messageResolver
-     * @param csvMessageInterpolator
+     * @param messageResolver SuperCsvAnnotation用のメッセージソース。
+     * @param csvMessageInterpolator SuperCsvAnnotation用のMessageInterpolator。
      * @throws NullPointerException {@literal if messageResolver or csvMessageInterpolator is null.}
      */
     public MessageInterpolatorAdapter(final MessageResolver messageResolver, final MessageInterpolator csvMessageInterpolator) {

--- a/src/test/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaCsvBeanValidatorTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/validation/beanvalidation/JakartaCsvBeanValidatorTest.java
@@ -1,0 +1,351 @@
+package com.github.mygreen.supercsv.validation.beanvalidation;
+
+import static com.github.mygreen.supercsv.tool.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.Range;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.github.mygreen.supercsv.annotation.CsvBean;
+import com.github.mygreen.supercsv.annotation.CsvColumn;
+import com.github.mygreen.supercsv.builder.BeanMapping;
+import com.github.mygreen.supercsv.builder.BeanMappingFactory;
+import com.github.mygreen.supercsv.localization.EncodingControl;
+import com.github.mygreen.supercsv.localization.MessageInterpolator;
+import com.github.mygreen.supercsv.localization.MessageResolver;
+import com.github.mygreen.supercsv.localization.ResourceBundleMessageResolver;
+import com.github.mygreen.supercsv.validation.CsvBindingErrors;
+import com.github.mygreen.supercsv.validation.CsvExceptionConverter;
+import com.github.mygreen.supercsv.validation.ValidationContext;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * {@link JakaratCsvBeanValidator}のテスタ
+ *
+ * @since 2.4
+ * @author T.TSUCHIE
+ *
+ */
+@Ignore("Jakarata Bean Validation 3.0 + Java11のときのみ")
+public class JakartaCsvBeanValidatorTest {
+    
+    @Rule
+    public TestName name = new TestName();
+    
+    private JakartaCsvBeanValidator csvValidator;
+    private JakartaCsvBeanValidator csvValidatorDefaultMessage;
+    private JakartaCsvBeanValidator csvValidatorCustomMessage;
+    
+    private BeanMappingFactory beanMappingFactory;
+    private CsvExceptionConverter exceptionConverter;
+    
+    private final Class<?>[] groupEmpty = new Class[]{};
+    
+    private MessageResolver testMessageResolver;
+    private MessageInterpolator messageInterpolator;
+    
+    @Before
+    public void setUp() throws Exception {
+        this.beanMappingFactory = new BeanMappingFactory();
+        this.exceptionConverter = new CsvExceptionConverter();
+        
+        this.testMessageResolver = new ResourceBundleMessageResolver(ResourceBundle.getBundle("TestMessages", new EncodingControl("UTF-8")));
+        this.messageInterpolator = new MessageInterpolator();
+        
+        this.csvValidator = new JakartaCsvBeanValidator();
+        
+        
+        {
+            // 標準メッセージのValidator
+            final Validator beanValidator = Validation.byDefaultProvider().configure()
+                    .messageInterpolator(new JakartaMessageInterpolatorAdapter(new ResourceBundleMessageResolver(), messageInterpolator))
+                    .buildValidatorFactory()
+                    .getValidator();
+            this.csvValidatorDefaultMessage = new JakartaCsvBeanValidator(beanValidator);
+        }
+        
+        {
+            // カスタムメッセージのValidator
+            final Validator beanValidator =  Validation.byDefaultProvider().configure()
+                    .messageInterpolator(new JakartaMessageInterpolatorAdapter(testMessageResolver, messageInterpolator))
+                    .buildValidatorFactory()
+                    .getValidator();
+            this.csvValidatorCustomMessage = new JakartaCsvBeanValidator(beanValidator);
+        }
+        
+    }
+    
+    // テスト用のグループ
+    private interface Group1 { }
+    private interface Group2 { }
+    private interface Group3 { }
+    private interface Group4 { }
+    
+    @CsvBean
+    private static class TestCsv {
+        
+        @CsvColumn(number=1)
+        @NotEmpty
+        private String id;
+        
+        @CsvColumn(number=2)
+        @Length(max=10)
+        @Pattern(regexp="[\\p{Alnum}]+", message="半角英数字で設定してください。", groups=Group1.class)
+        private String name;
+        
+        @CsvColumn(number=3)
+        @Range(min=0, max=100, groups=Group2.class)
+        private Integer age;
+        
+        @CsvColumn(number=4)
+        boolean used;
+        
+        @AssertTrue(message="{name}が設定されている際には、{age}は必須です。", groups=Group2.class)
+        boolean isValidAgeRequired() {
+            if(name != null && !name.isEmpty()) {
+                return age != null;
+            }
+            
+            return false;
+        }
+        
+        @DecimalMax(value="20", groups=Group3.class)
+        Integer getAge() {
+            return age;
+        }
+        
+        @AssertTrue(groups=Group4.class)
+        boolean isUsed() {
+            return used;
+        }
+    }
+    
+    /**
+     * 標準のValidatorの場合
+     */
+    @Test
+    public void testValidate_default() {
+        
+        Class<?>[] groups = groupEmpty;
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        
+        csvValidator.validate(record, bindingErrors, (ValidationContext)validationContext);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(testMessageResolver, messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("[2行, 1列] : 項目「id」の値は必須です。");
+        
+    }
+    
+    /**
+     * 標準のValidatorの場合 - 標準のCSVメッセージを使う場合
+     */
+    @Test
+    public void testValidate_default_csvMessage() {
+        
+        Class<?>[] groups = groupEmpty;
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        
+        csvValidatorDefaultMessage.validate(record, bindingErrors, (ValidationContext)validationContext);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(new ResourceBundleMessageResolver(), messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("[2行, 1列] : 項目「id」の値は必須です。");
+        
+    }
+    
+    /**
+     * グループ指定の場合
+     */
+    @Test
+    public void testValidate_groups() {
+        
+        Class<?>[] groups = new Class[]{Group1.class};
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        record.id = "a01";
+        record.name = "あいう";
+        
+        csvValidator.validate(record, bindingErrors, (ValidationContext)validationContext, groups);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(testMessageResolver, messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("半角英数字で設定してください。");
+        
+    }
+    
+    /**
+     * 相関チェックの場合
+     */
+    @Test
+    public void testValidate_relation() {
+        
+        Class<?>[] groups = new Class[]{Group2.class};
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        record.id = "a01";
+        record.name = "test";
+        
+        csvValidator.validate(record, bindingErrors, (ValidationContext)validationContext, groups);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(testMessageResolver, messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("名前が設定されている際には、年齢は必須です。");
+        
+    }
+    
+    /**
+     * getterメソッドの場合
+     */
+    @Test
+    public void testValidate_getter() {
+        
+        Class<?>[] groups = new Class[]{Group3.class};
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        record.id = "a01";
+        record.name = "test";
+        record.age = 40;
+        
+        csvValidator.validate(record, bindingErrors, (ValidationContext)validationContext, groups);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(testMessageResolver, messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("[2行, 3列] : 項目「age」の値（40）は、20以下の値を設定してください。");
+        
+    }
+    
+    /**
+     * getterメソッドの場合 - 標準のCSVメッセージを使用するう場合
+     */
+    @Test
+    public void testValidate_getter_csvMessage() {
+        
+        Class<?>[] groups = new Class[]{Group3.class};
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        record.id = "a01";
+        record.name = "test";
+        record.age = 40;
+        
+        csvValidatorDefaultMessage.validate(record, bindingErrors, (ValidationContext)validationContext, groups);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(new ResourceBundleMessageResolver(), messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("[2行, 3列] : 項目「age」の値（40）は、20以下の値を設定してください。");
+        
+    }
+    
+    /**
+     * getterメソッドの場合 - boolean
+     */
+    @Test
+    public void testValidate_getter_boolean() {
+        
+        Class<?>[] groups = new Class[]{Group4.class};
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        record.id = "a01";
+        record.used = false;
+        
+        csvValidator.validate(record, bindingErrors, (ValidationContext)validationContext, groups);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(testMessageResolver, messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("trueを設定してください。");
+        
+    }
+    
+    /**
+     * カスタマイズしたValidatorの場合
+     */
+    @Test
+    public void testValidate_custom() {
+        
+        Class<?>[] groups = groupEmpty;
+        CsvBindingErrors bindingErrors = new CsvBindingErrors(TestCsv.class);
+        
+        BeanMapping<TestCsv> beanMapping = beanMappingFactory.create(TestCsv.class, groupEmpty);
+        ValidationContext<TestCsv> validationContext = new ValidationContext<>(ANONYMOUS_CSVCONTEXT, beanMapping);
+        
+        TestCsv record = new TestCsv();
+        
+        csvValidatorCustomMessage.validate(record, bindingErrors, (ValidationContext)validationContext);
+        
+        List<String> messages = bindingErrors.getAllErrors().stream()
+                .map(error -> error.format(testMessageResolver, messageInterpolator))
+                .collect(Collectors.toList());
+        
+        assertThat(messages).hasSize(1)
+            .contains("[2行, 1列] : 項目「id」の値は必須です。");
+        
+    }
+    
+    
+}


### PR DESCRIPTION
Jakarta Bean Validation 3.0の対応

- 実装である Hibernate 8.0 はJava11以上が必要になるため、デフォルトは今まで通り Bean Validation 2.0(Hibernate 6.0)のまま。
- Bean Validation 3.0用のクラスとして `JakarataCsvBeanValidator` / `JakartaMessageInterpolatorAdapter` を追加。
- Bean Validation 3.0用のメッセージを CsvValidationMessages.properties` に追加。
