### PR TITLE
GitHub Actions のタイムゾーンの指定

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,9 @@ jobs:
         sudo update-locale LC_ALL=ja_JP.UTF-8
         sudo localectl status
     - name: Set up Time-Zone
-      run: sudo timedatectl set-timezone Asia/Tokyo
+      run: |
+        sudo timedatectl set-timezone Asia/Tokyo
+        date
     - uses: actions/checkout@v4
     - name: Set up JDK 1.8
       uses: actions/setup-java@v4
@@ -37,4 +39,7 @@ jobs:
       with:
         maven-version: 3.9.6
     - name: Build with Maven
+      env:
+        TZ: 'Asia/Tokyo'
       run: mvn -B clean verify -Dgpg.skip=true
+


### PR DESCRIPTION
DateTimeProcessorBuilderTest などの書式にタイムゾーン指定するときのテストが失敗するため、環境変数 `TZ=Asia/Tokyo` を指定。