### PR TITLE
GitHub Actionsでテスト結果が文字化けする事象の修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@ CSVのJavaライブラリであるSuperCSVに、アノテーション機能を�
 		<supercsv.version>2.4.0</supercsv.version>
 		<spring.version>4.3.2.RELEASE</spring.version>
 		<jacoco.include.package>com.github.mygreen.supercsv.*</jacoco.include.package>
+		<!--
+			surefire pluginのJaCoCoのエラー回避。
+			https://github.com/jacoco/jacoco/issues/964
+			https://github.com/eclipse-m2e/m2e-core/issues/1824
+		-->
+		<argLine>-Duser.language=ja -Duser.country=JP -Dfile.encoding=UTF-8</argLine>
 
 		<!-- SonarQubeの解析から除外したいファイル -->
 		<sonar.exclusions>
@@ -60,7 +66,7 @@ CSVのJavaライブラリであるSuperCSVに、アノテーション機能を�
 			**/*Test.*,
 			**/*.js,
 		</sonar.exclusions>
-		<sonar.projectName>${groupId}/${project.artifactId}</sonar.projectName>
+		<sonar.projectName>${project.groupId}/${project.artifactId}</sonar.projectName>
 		<sonar.host.url>https://sonarcloud.io/</sonar.host.url>
 		<sonar.organization>mygreen-github</sonar.organization>
 
@@ -185,13 +191,15 @@ $(document).ready(function() {
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
+					<!--
 					<argLine>${jacocoArgs} -Duser.language=ja -Duser.country=JP</argLine>
+					-->
 				</configuration>
 			</plugin>
 			<plugin>
 		        <groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.5</version>
+				<version>0.8.12</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -228,6 +236,7 @@ $(document).ready(function() {
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
+				<version>3.2.7</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@ CSVのJavaライブラリであるSuperCSVに、アノテーション機能を�
 
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
-    	<maven.compiler.target>1.8</maven.compiler.target>
-    	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<supercsv.version>2.4.0</supercsv.version>
 		<spring.version>4.3.2.RELEASE</spring.version>
 		<jacoco.include.package>com.github.mygreen.supercsv.*</jacoco.include.package>

--- a/src/main/java/com/github/mygreen/supercsv/localization/EncodingControl.java
+++ b/src/main/java/com/github/mygreen/supercsv/localization/EncodingControl.java
@@ -1,5 +1,6 @@
 package com.github.mygreen.supercsv.localization;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -54,13 +55,14 @@ public class EncodingControl extends ResourceBundle.Control {
             final String bundleName = toBundleName(baseName, locale);
             final String resourceName = toResourceName(bundleName, "properties");
             
-            try (InputStream stream = getResourceStream(loader, resourceName)) {
-                try (InputStreamReader isr = new InputStreamReader(stream, encoding)) {
-                    return new PropertyResourceBundle(isr);
-                }
+            try (InputStream stream = getResourceStream(loader, resourceName);
+                    InputStreamReader isr = new InputStreamReader(stream, encoding);
+                    BufferedReader reader = new BufferedReader(isr)) {
+                return new PropertyResourceBundle(reader);
             } catch (PrivilegedActionException e) {
                 throw(IOException) e.getException();
             }
+
         } else {
             // 「java.class」はサポートしない。
             // プロパティファイル(java.properties)のみサポートする。

--- a/src/test/resources/TestMessages.properties
+++ b/src/test/resources/TestMessages.properties
@@ -1,93 +1,96 @@
-#############################################
-# テスト用のメッセージの定義
-#############################################
+###############################################################
+# \u30c6\u30b9\u30c8\u7528\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306e\u5b9a\u7fa9
+# \u203b\u5fc5\u305aASCII\u30b3\u30fc\u30c9\u3067\u5b9a\u7fa9\u3059\u308b\u3053\u3068\u3002
+#   GitHubActions\u304b\u3089\u3060\u3068\u4f55\u6545\u304bUTF-8\u3060\u3068\u6587\u5b57\u5316\u3051\u3059\u308b\u305f\u3081\u3002
+###############################################################
 
-name=名前
-age=年齢
 
-## アノテーションの設定値
-nullRead.value1=あいう
-nullRead.value2=かきく
+name=\u540d\u524d
+age=\u5e74\u9f62
 
-defaultRead.value.string=あいう
+## \u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u306e\u8a2d\u5b9a\u5024
+nullRead.value1=\u3042\u3044\u3046
+nullRead.value2=\u304b\u304d\u304f
+
+defaultRead.value.string=\u3042\u3044\u3046
 defaultRead.value.int=1,234
 
-defaultWrite.value.string=あいう
+defaultWrite.value.string=\u3042\u3044\u3046
 defaultWrite.value.int=1,234
 
-# 再帰用のテスト
+# \u518d\u5e30\u7528\u306e\u30c6\u30b9\u30c8
 testRecursive.value={testRecursive.min}
 testRecursive.min={testRecursive.value}
 
 
-# パースエラー時のメッセージ
-#typeMismatch={csvContext} : 項目「{label}」の値（{validatedValue}）の書式は不正です。
+# \u30d1\u30fc\u30b9\u30a8\u30e9\u30fc\u6642\u306e\u30e1\u30c3\u30bb\u30fc\u30b8
+#typeMismatch={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306e\u66f8\u5f0f\u306f\u4e0d\u6b63\u3067\u3059\u3002
 
-typeMismatch.boolean={csvContext} : 項目「{label}」の値（{validatedValue}）は、trueの値「${f:join(trueValues, ', ')}」、またはfalseの値「${f:join(falseValues, ', ')}」の何れかの値で設定してください。
+typeMismatch.boolean={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001true\u306e\u5024\u300c${f:join(trueValues, ', ')}\u300d\u3001\u307e\u305f\u306ffalse\u306e\u5024\u300c${f:join(falseValues, ', ')}\u300d\u306e\u4f55\u308c\u304b\u306e\u5024\u3067\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 typeMismatch.java.lang.Boolean={typeMismatch.boolean}
 
-typeMismatch.char={csvContext} : 項目「{label}」の値は、空文字であるため不正です。
+typeMismatch.char={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u3001\u7a7a\u6587\u5b57\u3067\u3042\u308b\u305f\u3081\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Character={typeMismatch.char}
 
-typeMismatch.java.lang.Number={csvContext} : 項目「{label}」の値（{validatedValue}）は、数値の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
-typeMismatch.byte={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.java.lang.Number={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6570\u5024\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.byte={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Byte={typeMismatch.byte}
-typeMismatch.short={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.short={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Short={typeMismatch.short}
-typeMismatch.int={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.int={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Integer={typeMismatch.int}
-typeMismatch.long={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.long={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Long={typeMismatch.long}
-typeMismatch.float={csvContext} : 項目「{label}」の値（{validatedValue}）は、小数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.float={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5c0f\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Float={typeMismatch.float}
-typeMismatch.double={csvContext} : 項目「{label}」の値（{validatedValue}）は、小数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.double={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5c0f\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 typeMismatch.java.lang.Double={typeMismatch.double}
 
-typeMismatch.java.math.BigDecimal={csvContext} : 項目「{label}」の値（{validatedValue}）は、数値の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
-typeMismatch.java.math.BigInteger={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数の書式${empty(pattern) ? '' : '「' + pattern + '」'}として不正です。
+typeMismatch.java.math.BigDecimal={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6570\u5024\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.math.BigInteger={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u306e\u66f8\u5f0f${empty(pattern) ? '' : '\u300c' + pattern + '\u300d'}\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 
-typeMismatch.java.lang.Enum={csvContext} : 項目「{label}」の値（{validatedValue}）は、何れかの値「${f:join(enums, ', ')}」である必要があります。
+typeMismatch.java.lang.Enum={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u4f55\u308c\u304b\u306e\u5024\u300c${f:join(enums, ', ')}\u300d\u3067\u3042\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002
 
-typeMismatch.java.util.Date={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.java.util.Calendar={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.java.sql.Date={csvContext} : 項目「{label}」の値（{validatedValue}）は、日付の書式「{pattern}」として不正です。
-typeMismatch.java.sql.Time={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
-typeMismatch.java.sql.Timestamp={csvContext} : 項目「{label}」の値（{validatedValue}）は、タイムスタンプの書式「{pattern}」として不正です。
+typeMismatch.java.util.Date={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.util.Calendar={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.sql.Date={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u4ed8\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.sql.Time={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.sql.Timestamp={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u30bf\u30a4\u30e0\u30b9\u30bf\u30f3\u30d7\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 
-typeMismatch.java.time.LocalDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.java.time.LocalDate={csvContext} : 項目「{label}」の値（{validatedValue}）は、日付の書式「{pattern}」として不正です。
-typeMismatch.java.time.LocalTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
-typeMismatch.java.time.ZonedDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.java.time.OffsetDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.java.time.OffsetTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
-typeMismatch.java.time.Year={csvContext} : 項目「{label}」の値（{validatedValue}）は、年の書式「{pattern}」として不正です。
-typeMismatch.java.time.YearMonth={csvContext} : 項目「{label}」の値（{validatedValue}）は、年月の書式「{pattern}」として不正です。
-typeMismatch.java.time.MonthDay={csvContext} : 項目「{label}」の値（{validatedValue}）は、月日の書式「{pattern}」として不正です。
+typeMismatch.java.time.LocalDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.LocalDate={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u4ed8\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.LocalTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.ZonedDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.OffsetDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.OffsetTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.Year={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5e74\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.YearMonth={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5e74\u6708\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.java.time.MonthDay={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6708\u65e5\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 
-typeMismatch.org.joda.time.LocalDateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.org.joda.time.LocalDate={csvContext} : 項目「{label}」の値（{validatedValue}）は、日付の書式「{pattern}」として不正です。
-typeMismatch.org.joda.time.LocalTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、時刻の書式「{pattern}」として不正です。
-typeMismatch.org.joda.time.DateTime={csvContext} : 項目「{label}」の値（{validatedValue}）は、日時の書式「{pattern}」として不正です。
-typeMismatch.org.joda.time.YearMonth={csvContext} : 項目「{label}」の値（{validatedValue}）は、年月の書式「{pattern}」として不正です。
-typeMismatch.org.joda.time.MonthDay={csvContext} : 項目「{label}」の値（{validatedValue}）は、月日の書式「{pattern}」として不正です。
-
-
-# 独自のクラスタイプ
-typeMismatch.com.github.mygreen.supercsv.builder.GeneralProcessorBuilderTest$SampleObject={csvContext} : 項目「{label}」の値は、XMLの値として不正です。
+typeMismatch.org.joda.time.LocalDateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.org.joda.time.LocalDate={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u4ed8\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.org.joda.time.LocalTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6642\u523b\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.org.joda.time.DateTime={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u65e5\u6642\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.org.joda.time.YearMonth={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5e74\u6708\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+typeMismatch.org.joda.time.MonthDay={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6708\u65e5\u306e\u66f8\u5f0f\u300c{pattern}\u300d\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 
 
-# 独自のメッセージ
-fieldError.max={csvContext} : 項目「{label}」の値（${printer.print(validatedValue)}）は、${printer.print(max)}以内で入力してください。
-age.required={csvContext} : 項目「{label}」は、年齢が{maxAge}歳以上の場合には必須です。
-
-# Spring用のテストでの独自のクラスタイプ
-com.github.mygreen.supercsv.builder.spring.CsvUserNameExist.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、存在しません。
-typeMismatch.SampleCsv.homepage={csvContext} : 項目「{label}」の値（{validatedValue}）は、URLの書式として不正です。
-fieldError.homepage.supportedProtocol={csvContext} : 項目「{label}」の値（{validatedValue}）のプロトコル「{protocol}」はサポートしていません。
-com.github.mygreen.supercsv.builder.spring.UserMailPattern.message={csvContext} : 項目「{label}」の値（{validatedValue}）は、メールアドレスの書式として不正です。
+# \u72ec\u81ea\u306e\u30af\u30e9\u30b9\u30bf\u30a4\u30d7
+typeMismatch.com.github.mygreen.supercsv.builder.GeneralProcessorBuilderTest$SampleObject={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\u306f\u3001XML\u306e\u5024\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 
 
-ParseInt={csvContext} : 項目「{label}」の値（{validatedValue}）は、整数として不正です。
+# \u72ec\u81ea\u306e\u30e1\u30c3\u30bb\u30fc\u30b8
+fieldError.max={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08${printer.print(validatedValue)}\uff09\u306f\u3001${printer.print(max)}\u4ee5\u5185\u3067\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+age.required={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306f\u3001\u5e74\u9f62\u304c{maxAge}\u6b73\u4ee5\u4e0a\u306e\u5834\u5408\u306b\u306f\u5fc5\u9808\u3067\u3059\u3002
+
+# Spring\u7528\u306e\u30c6\u30b9\u30c8\u3067\u306e\u72ec\u81ea\u306e\u30af\u30e9\u30b9\u30bf\u30a4\u30d7
+com.github.mygreen.supercsv.builder.spring.CsvUserNameExist.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u5b58\u5728\u3057\u307e\u305b\u3093\u3002
+typeMismatch.SampleCsv.homepage={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001URL\u306e\u66f8\u5f0f\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+fieldError.homepage.supportedProtocol={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306e\u30d7\u30ed\u30c8\u30b3\u30eb\u300c{protocol}\u300d\u306f\u30b5\u30dd\u30fc\u30c8\u3057\u3066\u3044\u307e\u305b\u3093\u3002
+com.github.mygreen.supercsv.builder.spring.UserMailPattern.message={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u30e1\u30fc\u30eb\u30a2\u30c9\u30ec\u30b9\u306e\u66f8\u5f0f\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
+
+
+ParseInt={csvContext} : \u9805\u76ee\u300c{label}\u300d\u306e\u5024\uff08{validatedValue}\uff09\u306f\u3001\u6574\u6570\u3068\u3057\u3066\u4e0d\u6b63\u3067\u3059\u3002
 
 
 


### PR DESCRIPTION
### 主な修正内容
- GitHub Actionsのテスト実行にて、テスト用のプロパティファイル `TestMessages.properites` がUTF-8で定義していると文字化けするため、unicode に変更。
  - 理由は不明。
  - src/main にあるプロパティファイルはUTF-8でも問題ない。

### その他の修正内容

- EncodingControl.javaにてプロパティファイルを読み込むときに、BufferedReaderを介すよう修正。
- pom.xmlにて、surefire のJaCoCo用のオプション(`<argLine>`) を `<properties>` に切り出して定義するよう修正。