### PR TITLE
固定長サイズ処理クラスに、一括処理用のメソッドを追加

### DIFF
--- a/src/main/java/com/github/mygreen/supercsv/io/CsvAnnotationBeanWriter.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/CsvAnnotationBeanWriter.java
@@ -121,7 +121,7 @@ public class CsvAnnotationBeanWriter<T> extends AbstractCsvAnnotationBeanWriter<
             }
         }
         
-        super.flush();
+        flush();
         
     }
     

--- a/src/main/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanReader.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanReader.java
@@ -2,8 +2,15 @@ package com.github.mygreen.supercsv.io;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.supercsv.exception.SuperCsvException;
+
+import com.github.mygreen.supercsv.exception.SuperCsvBindingException;
 import com.github.mygreen.supercsv.exception.SuperCsvFixedSizeException;
+import com.github.mygreen.supercsv.exception.SuperCsvNoMatchColumnSizeException;
+import com.github.mygreen.supercsv.exception.SuperCsvNoMatchHeaderException;
 
 /**
  * アノテーションを元に固定長のCSVファイルを読み込むためのクラス。
@@ -36,6 +43,69 @@ public class FixedSizeCsvAnnotationBeanReader<T> extends AbstractCsvAnnotationBe
             errorMessages.addAll(exceptionConverter.convertAndFormat(e, beanMappingCache.getOriginal()));
             throw e;
         }
+    }
+    
+    /**
+     * レコードを全て読み込みます。
+     * <p>ヘッダー行も自動的に処理されます。</p>
+     * <p>レコード処理中に例外が発生した場合、その時点で処理を終了します。</p>
+     * 
+     * @return 読み込んだレコード情報。
+     * 
+     * @throws IOException レコードの読み込みに失敗した場合。
+     * @throws SuperCsvNoMatchColumnSizeException レコードのカラムサイズに問題がある場合
+     * @throws SuperCsvBindingException セルの値に問題がある場合
+     * @throws SuperCsvException 設定など、その他に問題がある場合
+     */
+    public List<T> readAll() throws IOException {
+        return readAll(false);
+    }
+    
+    /**
+     * レコードを全て読み込みます。
+     * <p>ヘッダー行も自動的に処理されます。</p>
+     * 
+     * @param continueOnError レコードの処理中に、
+     *        例外{@link SuperCsvNoMatchColumnSizeException}、{@link SuperCsvNoMatchColumnSizeException}、{@link SuperCsvBindingException}
+     *        が発生しても続行するかどう指定します。
+     *        trueの場合、例外が発生しても、次の処理を行います。
+     * @return 読み込んだレコード情報。
+     * 
+     * @throws IOException レコードの読み込みに失敗した場合。
+     * @throws SuperCsvNoMatchColumnSizeException レコードのカラムサイズに問題がある場合
+     * @throws SuperCsvBindingException セルの値に問題がある場合
+     * @throws SuperCsvException 設定など、その他に問題がある場合
+     */
+    public List<T> readAll(final boolean continueOnError) throws IOException {
+        
+        if(beanMappingCache.getOriginal().isHeader()) {
+            try {
+                getHeader(true);
+            } catch(SuperCsvNoMatchColumnSizeException | SuperCsvNoMatchHeaderException e) {
+                if(!continueOnError) {
+                    throw e;
+                }
+            }
+        }
+        
+        final List<T> list = new ArrayList<>();
+        
+        while(true) {
+            try {
+                final T record = read();
+                if(record == null) {
+                    break;
+                }
+                list.add(record);
+                
+            } catch(SuperCsvNoMatchColumnSizeException | SuperCsvBindingException e) {
+                if(!continueOnError) {
+                    throw e;
+                }
+            }
+        }
+        
+        return list;
     }
     
 }

--- a/src/main/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanWriter.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanWriter.java
@@ -176,7 +176,7 @@ public class FixedSizeCsvAnnotationBeanWriter<T> extends AbstractCsvAnnotationBe
             }
         }
         
-        super.flush();
+        flush();
         
     }
 }

--- a/src/main/java/com/github/mygreen/supercsv/io/LazyCsvAnnotationBeanWriter.java
+++ b/src/main/java/com/github/mygreen/supercsv/io/LazyCsvAnnotationBeanWriter.java
@@ -270,7 +270,7 @@ public class LazyCsvAnnotationBeanWriter<T> extends AbstractCsvAnnotationBeanWri
             }
         }
         
-        super.flush();
+        flush();
         
     }
     

--- a/src/test/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanReaderTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanReaderTest.java
@@ -74,6 +74,30 @@ public class FixedSizeCsvAnnotationBeanReaderTest {
 
     }
     
+    @Test
+    public void testReadAll_normal() throws IOException {
+        
+        File file = new File("src/test/data/test_read_fixed_normal.csv");
+
+        FixedSizeCsvAnnotationBeanReader<SampleFixedColumnBean> csvReader = FixedSizeCsvPreference.builder(SampleFixedColumnBean.class)
+                .build()
+                .csvReader(new InputStreamReader(new FileInputStream(file), Charset.forName("UTF-8")));
+
+        csvReader.setExceptionConverter(exceptionConverter);
+        
+        List<SampleFixedColumnBean> list = csvReader.readAll();
+        assertThat(list).hasSize(3);
+        
+        for(SampleFixedColumnBean bean : list) {
+            assertBean(bean);
+        }
+        
+        assertThat(csvReader.getErrorMessages()).hasSize(0);
+        
+        csvReader.close();
+        
+    }
+    
     /**
      * 列のサイズが不足している場合
      */

--- a/src/test/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanWriterTest.java
+++ b/src/test/java/com/github/mygreen/supercsv/io/FixedSizeCsvAnnotationBeanWriterTest.java
@@ -76,6 +76,33 @@ public class FixedSizeCsvAnnotationBeanWriterTest {
         
     }
     
+    @Test
+    public void testWriteAll_normal() throws Exception {
+        
+        // テストデータの作成
+        final List<SampleFixedColumnBean> list = createFixedColumnData();
+        
+        StringWriter strWriter = new StringWriter();
+        
+        FixedSizeCsvAnnotationBeanWriter<SampleFixedColumnBean> csvWriter = FixedSizeCsvPreference.builder(SampleFixedColumnBean.class)
+                .build()
+                .csvWriter(strWriter);
+        
+        csvWriter.writeAll(list);
+        csvWriter.flush();
+        
+        String actual = strWriter.toString();
+        System.out.println(actual);
+        
+        String expected = getTextFromFile("src/test/data/test_write_fixed_normal.csv", Charset.forName("UTF-8"));
+        assertThat(actual).isEqualTo(expected);
+        
+        assertThat(csvWriter.getErrorMessages()).hasSize(0);
+        
+        csvWriter.close();
+        
+    }
+    
     /**
      * 固定長サイズオーバーの場合 - 例外をスローすること
      */


### PR DESCRIPTION
- `FixedSizeCsvAnnotationBeanReader` / `FixedSizeCsvAnnotationBeanWriter`  に、それぞれ `readAll()` / `writeAll()` メソッドを追加。
- writeAllメソッド内で、継承元のflushメソッドを呼び出すときに、`super.` 指定を削除。
  - 将来的にflushメソッドを継承先でオーバーライドしたときに、正しく呼び出せるようにする。
